### PR TITLE
feat(tg-sanitize): add Telegram MarkdownV2 sanitizer

### DIFF
--- a/tg-sanitize/tg-sanitize
+++ b/tg-sanitize/tg-sanitize
@@ -33,6 +33,54 @@ function sanitizeRaw(text) {
 }
 
 /**
+ * Find `[label](url)` patterns and rewrite them via `cb(label, url)`.
+ * Unlike a simple `[^)]+` regex, this walks the URL portion character by
+ * character so that URLs containing balanced parentheses (e.g. many
+ * Wikipedia links) are captured intact. A `\)` inside the URL is treated
+ * as an escaped paren and does not close the link.
+ */
+function replaceLinks(input, cb) {
+  let out = '';
+  let i = 0;
+  while (i < input.length) {
+    // Look for `[`
+    if (input[i] !== '[') { out += input[i++]; continue; }
+    // Find the matching `]` for the label (no nested brackets supported)
+    const labelEnd = input.indexOf(']', i + 1);
+    if (labelEnd === -1 || input[labelEnd + 1] !== '(') {
+      out += input[i++]; continue;
+    }
+    const label = input.slice(i + 1, labelEnd);
+    // Walk the URL, tracking paren depth and skipping escaped chars
+    let j = labelEnd + 2;
+    let depth = 1;
+    let url = '';
+    while (j < input.length && depth > 0) {
+      const ch = input[j];
+      if (ch === '\\' && j + 1 < input.length) {
+        url += ch + input[j + 1];
+        j += 2;
+        continue;
+      }
+      if (ch === '(') { depth++; url += ch; j++; continue; }
+      if (ch === ')') {
+        depth--;
+        if (depth === 0) { j++; break; }
+        url += ch; j++; continue;
+      }
+      url += ch; j++;
+    }
+    if (depth !== 0) {
+      // Unbalanced — treat the `[` as literal and move on
+      out += input[i++]; continue;
+    }
+    out += cb(label, url);
+    i = j;
+  }
+  return out;
+}
+
+/**
  * Escape special chars while preserving intentional MarkdownV2 formatting:
  * - *bold*, _italic_, __underline__, ~strikethrough~, ||spoiler||
  * - `inline code`, ```pre blocks```
@@ -58,13 +106,22 @@ function sanitize(text) {
   t = t.replace(/`[^`]+`/g, hold);
 
   // Preserve links [text](url)
-  t = t.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (m, label, url) => {
+  // Use a balanced-paren matcher for the URL portion so URLs containing
+  // parentheses (e.g. Wikipedia links) are captured correctly. We walk the
+  // string manually after each `](` to find the matching closing paren.
+  t = replaceLinks(t, (label, url) => {
     // Escape special chars inside the label, but not the structural brackets
     const safeLabel = label.replace(SPECIAL, '\\$&');
-    const safeUrl = url; // URLs don't need escaping inside ()
+    // Per Telegram MarkdownV2 docs, inside `(url)` only `)` and `\` are
+    // special and must be escaped with a preceding `\`.
+    const safeUrl = url.replace(/[)\\]/g, '\\$&');
     return hold(`[${safeLabel}](${safeUrl})`);
   });
 
+  // TODO(nested-formatting): escaping all SPECIAL chars inside `inner` blocks
+  // prevents nested formatting like `*bold _italic_*` or `*bold with `code`*`.
+  // A proper fix needs a real MarkdownV2 parser that tracks nesting depth;
+  // tracked as a follow-up after the review-r1 fix PR.
   // Preserve bold **text** and *text*
   t = t.replace(/\*\*([^*]+)\*\*/g, (m, inner) => hold(`**${inner.replace(SPECIAL, '\\$&')}**`));
   t = t.replace(/\*([^*]+)\*/g, (m, inner) => hold(`*${inner.replace(SPECIAL, '\\$&')}*`));
@@ -82,9 +139,14 @@ function sanitize(text) {
   // Now escape everything remaining
   t = t.replace(SPECIAL, '\\$&');
 
-  // Restore placeholders
+  // Restore placeholders.
+  // CAREFUL: when the second arg to String.prototype.replace is a string,
+  // JavaScript interprets `$&`, `$\``, `$'`, `$1`–`$9`, and `$$` as special
+  // patterns — so a held URL or code block containing `$&` would be
+  // corrupted. Passing a function as the replacement bypasses that
+  // interpretation entirely and treats `val` as a pure literal.
   for (const { key, val } of placeholders) {
-    t = t.replace(key, val);
+    t = t.replace(key, () => val);
   }
 
   return t;

--- a/tg-sanitize/tg-sanitize
+++ b/tg-sanitize/tg-sanitize
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * tg-sanitize — Telegram MarkdownV2 sanitizer
+ *
+ * Escapes special characters per Telegram's MarkdownV2 rules.
+ * Preserves intentional formatting (bold, italic, code, links).
+ *
+ * Usage:
+ *   tg-sanitize "Hello world! This has (special) chars."
+ *   echo "text with ~tildes~ and dots." | tg-sanitize
+ *   tg-sanitize --raw "Escape EVERYTHING including *bold*"
+ *   tg-sanitize --keep-format "Keep *bold* and _italic_ but escape the rest"
+ *
+ * Modes:
+ *   --raw          Escape every special char (for plain text injection)
+ *   --keep-format  Preserve *bold*, _italic_, `code`, [links](url)  (default)
+ *
+ * Node.js library usage:
+ *   const { sanitize, sanitizeRaw } = require('./tg-sanitize');
+ *   sanitize("Hello (world)!")     // "Hello \\(world\\)\\!"
+ *   sanitizeRaw("*bold* text!")    // "\\*bold\\* text\\!"
+ */
+
+// Characters that must be escaped in MarkdownV2 (per Telegram docs)
+// _ * [ ] ( ) ~ ` > # + - = | { } . !
+const SPECIAL = /[_*\[\]()~`>#\+\-=|{}.!\\]/g;
+
+/**
+ * Escape ALL special chars — for plain text that should have zero formatting.
+ */
+function sanitizeRaw(text) {
+  return text.replace(SPECIAL, '\\$&');
+}
+
+/**
+ * Escape special chars while preserving intentional MarkdownV2 formatting:
+ * - *bold*, _italic_, __underline__, ~strikethrough~, ||spoiler||
+ * - `inline code`, ```pre blocks```
+ * - [link text](url)
+ *
+ * Strategy: temporarily replace known formatting with placeholders,
+ * escape everything else, then restore formatting.
+ */
+function sanitize(text) {
+  const placeholders = [];
+  let idx = 0;
+
+  function hold(match) {
+    const key = `\x00PH${idx++}\x00`;
+    placeholders.push({ key, val: match });
+    return key;
+  }
+
+  let t = text;
+
+  // Preserve code blocks first (they contain raw text)
+  t = t.replace(/```[\s\S]*?```/g, hold);
+  t = t.replace(/`[^`]+`/g, hold);
+
+  // Preserve links [text](url)
+  t = t.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (m, label, url) => {
+    // Escape special chars inside the label, but not the structural brackets
+    const safeLabel = label.replace(SPECIAL, '\\$&');
+    const safeUrl = url; // URLs don't need escaping inside ()
+    return hold(`[${safeLabel}](${safeUrl})`);
+  });
+
+  // Preserve bold **text** and *text*
+  t = t.replace(/\*\*([^*]+)\*\*/g, (m, inner) => hold(`**${inner.replace(SPECIAL, '\\$&')}**`));
+  t = t.replace(/\*([^*]+)\*/g, (m, inner) => hold(`*${inner.replace(SPECIAL, '\\$&')}*`));
+
+  // Preserve italic _text_ (but not __underline__ — already caught by bold)
+  t = t.replace(/__([^_]+)__/g, (m, inner) => hold(`__${inner.replace(SPECIAL, '\\$&')}__`));
+  t = t.replace(/_([^_]+)_/g, (m, inner) => hold(`_${inner.replace(SPECIAL, '\\$&')}_`));
+
+  // Preserve strikethrough ~text~
+  t = t.replace(/~([^~]+)~/g, (m, inner) => hold(`~${inner.replace(SPECIAL, '\\$&')}~`));
+
+  // Preserve spoiler ||text||
+  t = t.replace(/\|\|([^|]+)\|\|/g, (m, inner) => hold(`||${inner.replace(SPECIAL, '\\$&')}||`));
+
+  // Now escape everything remaining
+  t = t.replace(SPECIAL, '\\$&');
+
+  // Restore placeholders
+  for (const { key, val } of placeholders) {
+    t = t.replace(key, val);
+  }
+
+  return t;
+}
+
+// --- CLI ---
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const raw = args.includes('--raw');
+  const filtered = args.filter(a => !a.startsWith('--'));
+
+  // Read from args or stdin
+  if (filtered.length > 0) {
+    const input = filtered.join(' ');
+    process.stdout.write(raw ? sanitizeRaw(input) : sanitize(input));
+    if (process.stdout.isTTY) process.stdout.write('\n');
+  } else {
+    let buf = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', chunk => buf += chunk);
+    process.stdin.on('end', () => {
+      process.stdout.write(raw ? sanitizeRaw(buf) : sanitize(buf));
+    });
+  }
+}
+
+// Exports for use as a library
+module.exports = { sanitize, sanitizeRaw };


### PR DESCRIPTION
## Summary

Adds a self-contained Node.js MarkdownV2 sanitizer that has been sitting untracked in the working tree since March 30. Found during an audit tonight.

## Why it matters

Throughout the April 6 overnight session, every Telegram reply with special characters (`=`, `!`, `.`, `(`, `)`) had to be manually escaped or it would fail with `Bad Request: can't parse entities`. This script does that automatically and preserves intentional formatting (bold, italic, code, links, strikethrough, spoiler).

## Modes

- **Auto-format** (default): preserves `*bold*`, `_italic_`, `` `code` ``, `[links](url)`, etc., escapes everything else
- **Raw**: escapes every special character

## CLI

```
tg-sanitize "Hello (world)!"            # auto-preserves format
tg-sanitize --raw "Plain *text*!"       # escapes everything
echo "1.5 = ok" | tg-sanitize           # reads stdin
```

## Library

```js
const { sanitize, sanitizeRaw } = require('./tg-sanitize');
sanitize("Hello (world)!")  // → "Hello \\(world\\)\\!"
```

## Test plan

- [x] Plain text with parens, dots, equals, exclamations
- [x] Markdown with bold + italic + code + parens
- [x] Strikethrough, spoiler, links
- [ ] Manual integration test against real Telegram API (after merge + symlink)

## Follow-up

After merge, in a separate PR:
1. Symlink `~/bin/tg-sanitize` → this script
2. Optionally wire into the Telegram reply tool path so MarkdownV2 escaping becomes automatic

🤖 Generated with [Claude Code](https://claude.com/claude-code)