### PR TITLE
feat(world-init): proof-of-concept bootstrap for ~/.world/

### DIFF
--- a/world-init/README.md
+++ b/world-init/README.md
@@ -1,0 +1,69 @@
+# world-init
+
+Bootstrap the `~/.world/` directory structure per ADR 0006.
+
+## What it does
+
+Creates the canonical `~/.world/` layout:
+
+```
+~/.world/
+├── AGENTS.md               ← the index
+├── reference/              (facts that don't change)
+│   ├── ports.md
+│   ├── services.md
+│   ├── secrets.md
+│   ├── shared-hosting.md
+│   └── tooling-map.md
+├── guides/                 (how to do tasks)
+│   ├── deploy-cpc.md
+│   ├── add-a-skill.md
+│   ├── add-a-tool.md
+│   ├── rebuild-vps.md
+│   └── share-a-doc.md
+├── conventions/            (rules that always apply)
+│   ├── gitflow.md
+│   ├── port-allocation.md
+│   ├── tool-design-principles.md
+│   ├── memory-system.md
+│   └── changelog-discipline.md
+└── host/                   (VPS-specific)
+    ├── AGENTS.md
+    └── manifest.yml
+```
+
+By default, each file is seeded as a stub with a TODO note. Use `--template` to copy pre-filled content from a directory (intended for CPC's `.world-templates/`).
+
+## Usage
+
+```bash
+# Initialize with empty stubs
+world-init
+
+# Preview what would happen without writing
+world-init --dry-run
+
+# Overwrite existing files
+world-init --force
+
+# Seed from a template directory (e.g., CPC's .world-templates)
+world-init --template ~/code/claude-pocket-console/.world-templates
+```
+
+## Idempotent
+
+Safe to run multiple times. By default, existing files are skipped unless `--force` is used. Missing files and directories are created on each run.
+
+## Environment
+
+- `WORLD_DIR` — override the default `~/.world/` location (useful for testing)
+
+## Status
+
+Phase 1 proof of concept per ADR 0006. Phase 2 (CPC `.world-templates/` integration) and Phase 3 (per-project overlay support) are future work.
+
+## Related
+
+- ADR 0006: `.world/` directory bootstrap and config precedence
+- ADR 0001: CPC + toolbox packaging (`.world-templates/` lives in CPC)
+- `~/claudes-world/knowledge/adr/0006-world-directory-bootstrap-and-precedence.md`

--- a/world-init/world-init
+++ b/world-init/world-init
@@ -1,0 +1,152 @@
+#!/bin/bash
+# world-init — bootstrap ~/.world/ on a fresh host
+#
+# Creates the ~/.world/ directory structure per ADR 0006 and seeds it
+# with either empty stub files or copies from a template source.
+#
+# Usage:
+#   world-init                   # init with empty stubs
+#   world-init --dry-run         # show what would happen
+#   world-init --force           # overwrite existing files
+#   world-init --template DIR    # copy stubs from a template directory
+#
+# Idempotent: safe to run multiple times. By default, only creates
+# files that don't already exist.
+#
+# Status: Proof-of-concept per ADR 0006. Not yet integrated with
+# CPC's .world-templates/ (that comes in Phase 2).
+
+set -euo pipefail
+
+WORLD="${WORLD_DIR:-$HOME/.world}"
+DRY_RUN=0
+FORCE=0
+TEMPLATE=""
+
+log() {
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "[dry-run] $*"
+  else
+    echo "$*"
+  fi
+}
+
+usage() {
+  sed -n '2,16p' "$0" | sed 's/^# \?//'
+  exit 0
+}
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --force)   FORCE=1; shift ;;
+    --template) TEMPLATE="$2"; shift 2 ;;
+    --help|-h) usage ;;
+    *) echo "error: unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Directory structure per ADR 0006
+DIRS=(
+  "reference"
+  "guides"
+  "conventions"
+  "host"
+)
+
+# Files to seed (relative to $WORLD)
+# Format: "relative_path|title|description"
+FILES=(
+  "AGENTS.md|Claude's World (Index)|Root index — read this first"
+  "reference/ports.md|Port Reservations|Canonical port assignments and registry"
+  "reference/services.md|Active Services|systemd units, cron jobs, long-running processes"
+  "reference/secrets.md|Secrets Locations|Where each secret lives and what it's for"
+  "reference/shared-hosting.md|Shared File Hosting|~/shared, Caddy, cloudflared, R2"
+  "reference/tooling-map.md|Tooling Map|Every script in ~/bin and toolbox, what it does"
+  "guides/deploy-cpc.md|Deploy CPC|Release tagging, prod restart"
+  "guides/add-a-skill.md|Add a Claude Code Skill|SKILL.md format, registration, testing"
+  "guides/add-a-tool.md|Add a Tool to Toolbox|Directory structure, ~/bin symlinks"
+  "guides/rebuild-vps.md|Rebuild the VPS|Disaster recovery walkthrough"
+  "guides/share-a-doc.md|Share a Markdown Doc|Using send-md and share-doc"
+  "conventions/gitflow.md|Gitflow|Branch discipline, PR policy"
+  "conventions/port-allocation.md|Port Allocation|The 38/48/58 convention, port-for, worktree binding"
+  "conventions/tool-design-principles.md|Tool Design Principles|How to think about adding tools"
+  "conventions/memory-system.md|Memory System|What to write to memory, what NOT to"
+  "conventions/changelog-discipline.md|Changelog Discipline|When to update VPS_CHANGELOG vs AGENTIC_HOST_CHANGELOG"
+  "host/AGENTS.md|Host AGENTS.md|VPS-specific rules and warnings"
+  "host/manifest.yml|Backup Manifest|Per ADR 0004 — declarative backup inventory"
+)
+
+# --- Main ---
+
+log "world-init: initializing Claude's World at $WORLD"
+[[ -n "$TEMPLATE" ]] && log "  template source: $TEMPLATE"
+[[ $FORCE -eq 1 ]] && log "  force mode: existing files will be overwritten"
+
+# Create directory structure
+for dir in "${DIRS[@]}"; do
+  target="$WORLD/$dir"
+  if [[ ! -d "$target" ]]; then
+    log "  mkdir $target"
+    [[ $DRY_RUN -eq 0 ]] && mkdir -p "$target"
+  fi
+done
+
+# Seed files
+created=0
+skipped=0
+for entry in "${FILES[@]}"; do
+  IFS='|' read -r relpath title description <<< "$entry"
+  target="$WORLD/$relpath"
+  source=""
+
+  # Determine source
+  if [[ -n "$TEMPLATE" && -f "$TEMPLATE/$relpath" ]]; then
+    source="$TEMPLATE/$relpath"
+  fi
+
+  # Skip if exists and not --force
+  if [[ -f "$target" && $FORCE -eq 0 ]]; then
+    log "  skip: $target (exists)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [[ -n "$source" ]]; then
+    log "  copy: $source -> $target"
+    [[ $DRY_RUN -eq 0 ]] && cp "$source" "$target"
+  else
+    # Create stub
+    log "  stub: $target"
+    if [[ $DRY_RUN -eq 0 ]]; then
+      cat > "$target" <<STUB
+# ${title}
+
+> **Status:** Stub. To be filled in.
+
+${description}
+
+## See also
+
+- ADR 0006: .world/ directory bootstrap
+STUB
+    fi
+  fi
+  created=$((created + 1))
+done
+
+# Summary
+log ""
+log "world-init: done"
+log "  created/updated: $created"
+log "  skipped (exists): $skipped"
+log "  location: $WORLD"
+
+if [[ $DRY_RUN -eq 0 && $created -gt 0 ]]; then
+  echo ""
+  echo "Next steps:"
+  echo "  1. Edit $WORLD/AGENTS.md to make it the bootstrap index"
+  echo "  2. Fill in the stub files with actual content"
+  echo "  3. Update ~/AGENTS.md to point at ~/.world/AGENTS.md"
+fi


### PR DESCRIPTION
## Summary

Phase 1 of ADR 0006 (.world/ directory bootstrap). A bash script that creates the canonical \`~/.world/\` structure with stub files.

## What it does

Creates:
\`\`\`
~/.world/
├── AGENTS.md
├── reference/  (ports, services, secrets, shared-hosting, tooling-map)
├── guides/     (deploy-cpc, add-a-skill, add-a-tool, rebuild-vps, share-a-doc)
├── conventions/ (gitflow, port-allocation, tool-design, memory-system, changelog-discipline)
└── host/       (AGENTS.md, manifest.yml)
\`\`\`

Each file is a titled stub with a status note and ADR link. Can be overridden with \`--template DIR\` to copy pre-filled content from a templates directory (intended for CPC's future \`.world-templates/\`).

## Features

- **Idempotent**: skips existing files by default
- **\`--dry-run\`**: preview without writing
- **\`--force\`**: overwrite existing
- **\`--template DIR\`**: copy from template source
- **\`WORLD_DIR\`** env var: useful for testing

## Test plan

- [x] Dry run produces expected mkdir + stub plan
- [x] Real run creates 4 directories and 18 stub files
- [x] Each stub has title, status, description, ADR reference
- [x] Re-run is idempotent (skips existing)
- [ ] Test \`--force\` mode (after merge)
- [ ] Test \`--template\` mode (after CPC Phase 2 adds \`.world-templates/\`)

## Not yet integrated

- CPC \`.world-templates/\` doesn't exist (Phase 2)
- \`~/AGENTS.md\` bootstrap pointer not auto-created (Phase 4 cutover)
- Per-project overlay walking not implemented (Phase 4)

## Next steps after merge

1. Symlink \`~/bin/world-init\` to this script (or wait for ADR 0008 migration)
2. Consider running \`world-init\` on the host to create \`~/.world/\` (non-destructive since it only creates stubs)
3. Phase 2: add \`.world-templates/\` to CPC

## Related

- ADR 0006: .world/ directory bootstrap and config precedence
- ADR 0001: CPC + toolbox packaging (where templates will ship from)
- ADR 0008: ~/bin migration plan (where the symlink step is tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)