### PR TITLE
fix(hooks): address Gemini high-severity review items on #4

### DIFF
--- a/hooks/agent-stop-hook
+++ b/hooks/agent-stop-hook
@@ -13,7 +13,11 @@ echo "" >> /tmp/agent-hooks.log
 AGENT_ID=$(echo "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null || true)
 AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // "agent"' 2>/dev/null || true)
 AGENT_SHORT="${AGENT_ID:0:8}"
-LAST_MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // empty' 2>/dev/null | head -c 2000 || true)
+# Per Gemini review: `head -c 2000` truncates by BYTES, which can split multi-byte
+# UTF-8 characters (emoji, CJK, accents) mid-byte and produce invalid UTF-8 that
+# Telegram's API rejects with HTTP 400. Use Python string slicing for UTF-8-safe
+# truncation by character count (Telegram's text limit is in characters, not bytes).
+LAST_MSG=$(echo "$INPUT" | jq -r '.last_assistant_message // empty' 2>/dev/null | python3 -c "import sys; sys.stdout.write(sys.stdin.read()[:2000])" || true)
 TIMESTAMP=$(TZ=America/New_York date '+%-I:%M %p ET')
 
 HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)

--- a/hooks/voice-hook
+++ b/hooks/voice-hook
@@ -84,9 +84,15 @@ echo "Sending Telegram reply and outputting JSON" >> "$LOG"
 
 # Send transcription as a quoted reply to the user on Telegram
 if [ -n "$CHAT_ID" ] && [ -n "$MSG_ID" ]; then
+  # Per Gemini review: the transcription is interpolated into an HTML-formatted
+  # Telegram message, so raw `<`, `>`, `&` in the transcript would break parsing
+  # (or enable tag injection). Escape `&` FIRST so the later `<`/`>` substitutions
+  # don't double-escape the ampersands we just inserted.
+  ESCAPED_TRANSCRIPTION=$(printf '%s' "$TRANSCRIPTION" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+
   # Expandable blockquote: collapsed by default, tap to expand
   QUOTED="<blockquote expandable><b>Transcription:</b>
-<i>${TRANSCRIPTION}</i></blockquote>"
+<i>${ESCAPED_TRANSCRIPTION}</i></blockquote>"
 
   curl -s -X POST "https://api.telegram.org/bot${BOTTOKEN}/sendMessage" \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary

Addresses the two HIGH-severity items from Gemini's review of #4.

### HIGH #1 — UTF-8 truncation in `hooks/agent-stop-hook`
`head -c 2000` truncated by bytes, which could split multi-byte UTF-8 characters (emoji, CJK, accents) mid-byte and produce invalid UTF-8 that Telegram's API rejects with HTTP 400. Replaced with a Python one-liner (`sys.stdout.write(sys.stdin.read()[:2000])`) which slices by character count — the correct semantic unit since Telegram's text limit is characters, not bytes.

### HIGH #2 — Unescaped transcription in HTML blockquote in `hooks/voice-hook`
The Whisper transcription was interpolated raw into an HTML-formatted Telegram message inside `<blockquote expandable>...</blockquote>`. Raw `<`, `>`, `&` would break parsing or permit tag injection. Added a `sed` HTML escape pipeline that escapes `&` FIRST, then `<` and `>`, to avoid double-escaping the ampersands just inserted.

Inline comments on both fixes point to this review.

## Test plan

- [ ] agent-stop-hook: pipe a string ending in an emoji at the byte boundary through the new Python slice; confirm valid UTF-8
- [ ] voice-hook: send a voice note whose transcription contains `<`, `>`, `&`; confirm Telegram renders it as literal text with no HTML parse errors
- [ ] Confirm existing happy-path behavior (plain ASCII transcriptions, normal agent stop messages) unchanged

## Notes

- Minimum-change patches; no refactor.
- **Do not merge** — waiting for Gemini re-review.