### PR TITLE
fix(tg-sanitize): Gemini review-r1 high-severity fixes

### DIFF
--- a/tg-sanitize/tg-sanitize
+++ b/tg-sanitize/tg-sanitize
@@ -33,6 +33,54 @@ function sanitizeRaw(text) {
 }
 
 /**
+ * Find `[label](url)` patterns and rewrite them via `cb(label, url)`.
+ * Unlike a simple `[^)]+` regex, this walks the URL portion character by
+ * character so that URLs containing balanced parentheses (e.g. many
+ * Wikipedia links) are captured intact. A `\)` inside the URL is treated
+ * as an escaped paren and does not close the link.
+ */
+function replaceLinks(input, cb) {
+  let out = '';
+  let i = 0;
+  while (i < input.length) {
+    // Look for `[`
+    if (input[i] !== '[') { out += input[i++]; continue; }
+    // Find the matching `]` for the label (no nested brackets supported)
+    const labelEnd = input.indexOf(']', i + 1);
+    if (labelEnd === -1 || input[labelEnd + 1] !== '(') {
+      out += input[i++]; continue;
+    }
+    const label = input.slice(i + 1, labelEnd);
+    // Walk the URL, tracking paren depth and skipping escaped chars
+    let j = labelEnd + 2;
+    let depth = 1;
+    let url = '';
+    while (j < input.length && depth > 0) {
+      const ch = input[j];
+      if (ch === '\\' && j + 1 < input.length) {
+        url += ch + input[j + 1];
+        j += 2;
+        continue;
+      }
+      if (ch === '(') { depth++; url += ch; j++; continue; }
+      if (ch === ')') {
+        depth--;
+        if (depth === 0) { j++; break; }
+        url += ch; j++; continue;
+      }
+      url += ch; j++;
+    }
+    if (depth !== 0) {
+      // Unbalanced — treat the `[` as literal and move on
+      out += input[i++]; continue;
+    }
+    out += cb(label, url);
+    i = j;
+  }
+  return out;
+}
+
+/**
  * Escape special chars while preserving intentional MarkdownV2 formatting:
  * - *bold*, _italic_, __underline__, ~strikethrough~, ||spoiler||
  * - `inline code`, ```pre blocks```
@@ -58,13 +106,22 @@ function sanitize(text) {
   t = t.replace(/`[^`]+`/g, hold);
 
   // Preserve links [text](url)
-  t = t.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (m, label, url) => {
+  // Use a balanced-paren matcher for the URL portion so URLs containing
+  // parentheses (e.g. Wikipedia links) are captured correctly. We walk the
+  // string manually after each `](` to find the matching closing paren.
+  t = replaceLinks(t, (label, url) => {
     // Escape special chars inside the label, but not the structural brackets
     const safeLabel = label.replace(SPECIAL, '\\$&');
-    const safeUrl = url; // URLs don't need escaping inside ()
+    // Per Telegram MarkdownV2 docs, inside `(url)` only `)` and `\` are
+    // special and must be escaped with a preceding `\`.
+    const safeUrl = url.replace(/[)\\]/g, '\\$&');
     return hold(`[${safeLabel}](${safeUrl})`);
   });
 
+  // TODO(nested-formatting): escaping all SPECIAL chars inside `inner` blocks
+  // prevents nested formatting like `*bold _italic_*` or `*bold with `code`*`.
+  // A proper fix needs a real MarkdownV2 parser that tracks nesting depth;
+  // tracked as a follow-up after the review-r1 fix PR.
   // Preserve bold **text** and *text*
   t = t.replace(/\*\*([^*]+)\*\*/g, (m, inner) => hold(`**${inner.replace(SPECIAL, '\\$&')}**`));
   t = t.replace(/\*([^*]+)\*/g, (m, inner) => hold(`*${inner.replace(SPECIAL, '\\$&')}*`));
@@ -82,9 +139,14 @@ function sanitize(text) {
   // Now escape everything remaining
   t = t.replace(SPECIAL, '\\$&');
 
-  // Restore placeholders
+  // Restore placeholders.
+  // CAREFUL: when the second arg to String.prototype.replace is a string,
+  // JavaScript interprets `$&`, `$\``, `$'`, `$1`–`$9`, and `$$` as special
+  // patterns — so a held URL or code block containing `$&` would be
+  // corrupted. Passing a function as the replacement bypasses that
+  // interpretation entirely and treats `val` as a pure literal.
   for (const { key, val } of placeholders) {
-    t = t.replace(key, val);
+    t = t.replace(key, () => val);
   }
 
   return t;


### PR DESCRIPTION
Addresses the Gemini review on #3 (commit `5f44c61`). Targets the feature branch — orchestrator will merge this into `feat/add-tg-sanitize` after re-review, then merge #3 into `main`.

## Fixes

### HIGH #1 — URL escaping in inline links (line 66)
[Gemini comment](https://github.com/claudes-world/toolbox/pull/3#discussion_r) — `[text](url)` was passing the URL through without escaping `)` or `\`, and the `[^)]+` regex couldn't capture URLs with balanced parens (e.g. Wikipedia links).

- Replaced the link regex with a small `replaceLinks()` walker that tracks paren depth and treats `\)` as an escaped paren.
- After capture, escapes `)` and `\` inside the URL portion per Telegram MarkdownV2 spec.

### HIGH #2 — Placeholder restoration corruption (line 87)
Gemini correctly flagged that `t.replace(key, val)` interprets `$&`, `$1`–`$9`, `$$`, `` $` ``, and `$'` inside the **string** replacement arg in JavaScript. (The original task brief said this was Python — the file is actually Node.js, but the bug is real all the same.) So a held code block or URL containing `$&` would be silently corrupted on restore.

- Switched to a function replacement: `t.replace(key, () => val)` treats `val` as a pure literal.

Smoke-test inputs that now round-trip cleanly:

| input | output |
| --- | --- |
| `` `cost is $5 and $&` `` | `` `cost is $5 and $&` `` |
| `` `use $1 or $$ here` `` | `` `use $1 or $$ here` `` |
| `[link](https://x?a=1$&b=2)` | `[link](https://x?a=1$&b=2)` |
| `[the article](https://en.wikipedia.org/wiki/Foo_(bar))` | `[the article](https://en.wikipedia.org/wiki/Foo_(bar\))` |

### MEDIUM #1 — Nested formatting blocked (line 70)
Acknowledged but **deferred**. Proper nested formatting (`*bold _italic_*`, `` *bold `code`* ``) requires a real MarkdownV2 parser that tracks nesting depth — too big for a review-fix round.

- Added a `TODO(nested-formatting)` comment at the relevant block.
- Tracking as a follow-up after this PR lands.

## Test plan
- [x] Manual smoke tests against `node -e` for the inputs in the table above
- [ ] Re-review by Gemini
- [ ] Orchestrator merges this into `feat/add-tg-sanitize`
- [ ] Orchestrator merges #3 into `main`