### PR TITLE
fix(telegram): reply keyboard reattach + shared launcher helper

### DIFF
--- a/hooks/actions-hook
+++ b/hooks/actions-hook
@@ -13,14 +13,8 @@ BOTTOKEN=$(grep TELEGRAM_BOT_TOKEN /home/claude/.claude/channels/telegram/.env 2
 
 HOOK_CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)
 . "$(dirname "$(readlink -f "$0")")/common.sh"
+. "$(dirname "$(readlink -f "$0")")/lib/launcher-keyboard.sh"
 CHAT_ID="$TELEGRAM_CHAT_ID"
-
-# Generate a fresh JWT for the Voice button web_app URL (matches launcher-hook).
-JWT_SECRET="${BOTTOKEN}"
-JWT_HEADER=$(echo -n '{"alg":"HS256","typ":"JWT"}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
-JWT_PAYLOAD=$(echo -n "{\"sub\":\"${CHAT_ID}\",\"iat\":$(date +%s),\"exp\":$(($(date +%s) + 604800))}" | base64 -w0 | tr '+/' '-_' | tr -d '=')
-JWT_SIGNATURE=$(echo -n "${JWT_HEADER}.${JWT_PAYLOAD}" | openssl dgst -sha256 -hmac "${JWT_SECRET}" -binary | base64 -w0 | tr '+/' '-_' | tr -d '=')
-CPC_AUTH_TOKEN="${JWT_HEADER}.${JWT_PAYLOAD}.${JWT_SIGNATURE}"
 
 send_msg() {
   local text="$1"
@@ -46,7 +40,7 @@ ACTIONS_MENU='{"keyboard":[[{"text":"📊 Usage (7d)"},{"text":"📊 Usage (30d)
 # Develop button uses https://cpc.claude.do/dev/?token=... — we tried the
 # t.me/claude_do_bot/dev BotFather direct link but Telegram rejects it at
 # sendMessage with BUTTON_URL_INVALID. See launcher-hook for the full story.
-LAUNCHER="{\"keyboard\":[[{\"text\":\"⚡️\\nActions\"},{\"text\":\"📱\\nDevelop\",\"web_app\":{\"url\":\"https://cpc.claude.do/dev/?token=${CPC_AUTH_TOKEN}\"}},{\"text\":\"🎙️\\nVoice\",\"web_app\":{\"url\":\"https://cpc.claude.do/#voice&token=${CPC_AUTH_TOKEN}\"}},{\"text\":\"📝\\nScrum\"}]],\"resize_keyboard\":true,\"is_persistent\":true}"
+LAUNCHER=$(build_launcher_reply_markup "$CHAT_ID" "$BOTTOKEN")
 
 case "$CONTENT" in
   *"⚡ Actions"*|*"⚡️Actions"*)

--- a/hooks/launcher-hook
+++ b/hooks/launcher-hook
@@ -83,6 +83,7 @@ _cleanup_telegram_orphans() {
 _cleanup_telegram_orphans
 
 . "$(dirname "$(readlink -f "$0")")/common.sh"
+. "$(dirname "$(readlink -f "$0")")/lib/launcher-keyboard.sh"
 
 [ -z "$BOTTOKEN" ] && exit 0
 [ -z "$TELEGRAM_CHAT_ID" ] && exit 0
@@ -95,12 +96,7 @@ if [ ! -f "$ACTIVE_CHAT" ] && [ -d "${HOOK_CWD}/.claude" ]; then
   echo "$CHAT_ID" > "$ACTIVE_CHAT"
 fi
 
-# Generate JWT for keyboard auth (fallback when initData is unavailable)
-JWT_SECRET="${BOTTOKEN}"
-JWT_HEADER=$(echo -n '{"alg":"HS256","typ":"JWT"}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
-JWT_PAYLOAD=$(echo -n "{\"sub\":\"${CHAT_ID}\",\"iat\":$(date +%s),\"exp\":$(($(date +%s) + 604800))}" | base64 -w0 | tr '+/' '-_' | tr -d '=')
-JWT_SIGNATURE=$(echo -n "${JWT_HEADER}.${JWT_PAYLOAD}" | openssl dgst -sha256 -hmac "${JWT_SECRET}" -binary | base64 -w0 | tr '+/' '-_' | tr -d '=')
-CPC_AUTH_TOKEN="${JWT_HEADER}.${JWT_PAYLOAD}.${JWT_SIGNATURE}"
+LAUNCHER_REPLY_MARKUP=$(build_launcher_reply_markup "$CHAT_ID" "$BOTTOKEN")
 
 # NOTE on the Develop button URL:
 # We tried using https://t.me/claude_do_bot/dev (BotFather direct link) so the
@@ -115,19 +111,9 @@ CPC_AUTH_TOKEN="${JWT_HEADER}.${JWT_PAYLOAD}.${JWT_SIGNATURE}"
 # UX surface entirely.
 curl -s -X POST "https://api.telegram.org/bot${BOTTOKEN}/sendMessage" \
   -H "Content-Type: application/json" \
-  -d "{
-    \"chat_id\": \"${CHAT_ID}\",
-    \"text\": \"Session started.\",
-    \"reply_markup\": {
-      \"keyboard\": [
-        [
-          {\"text\": \"⚡️\nActions\"},
-          {\"text\": \"📱\nDevelop\", \"web_app\": {\"url\": \"https://cpc.claude.do/dev/?token=${CPC_AUTH_TOKEN}\"}},
-          {\"text\": \"🎙️\nVoice\", \"web_app\": {\"url\": \"https://cpc.claude.do/#voice&token=${CPC_AUTH_TOKEN}\"}},
-          {\"text\": \"📝\nScrum\"}
-        ]
-      ],
-      \"resize_keyboard\": true,
-      \"is_persistent\": true
-    }
-  }"
+  -d "$(jq -n \
+    --arg chat_id "$CHAT_ID" \
+    --arg text "Session started." \
+    --argjson reply_markup "$LAUNCHER_REPLY_MARKUP" \
+    '{chat_id: $chat_id, text: $text, reply_markup: $reply_markup}'
+  )"

--- a/hooks/lib/launcher-keyboard.sh
+++ b/hooks/lib/launcher-keyboard.sh
@@ -1,0 +1,38 @@
+# Shared launcher keyboard builder for Telegram hooks.
+# Usage:
+#   LAUNCHER_REPLY_MARKUP=$(build_launcher_reply_markup "$CHAT_ID" "$BOTTOKEN")
+
+build_cpc_auth_token() {
+  local chat_id="$1"
+  local bot_token="$2"
+  local now
+  local jwt_header
+  local jwt_payload
+  local jwt_signature
+
+  now=$(date +%s)
+  jwt_header=$(printf '%s' '{"alg":"HS256","typ":"JWT"}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
+  jwt_payload=$(printf '{"sub":"%s","iat":%s,"exp":%s}' "$chat_id" "$now" "$((now + 604800))" | base64 -w0 | tr '+/' '-_' | tr -d '=')
+  jwt_signature=$(printf '%s' "${jwt_header}.${jwt_payload}" | openssl dgst -sha256 -hmac "${bot_token}" -binary | base64 -w0 | tr '+/' '-_' | tr -d '=')
+
+  printf '%s' "${jwt_header}.${jwt_payload}.${jwt_signature}"
+}
+
+build_launcher_reply_markup() {
+  local chat_id="$1"
+  local bot_token="$2"
+  local cpc_auth_token
+
+  cpc_auth_token=$(build_cpc_auth_token "$chat_id" "$bot_token")
+
+  jq -cn --arg token "$cpc_auth_token" '{
+    keyboard: [[
+      {text: "⚡️\nActions"},
+      {text: "📱\nDevelop", web_app: {url: ("https://cpc.claude.do/dev/?token=" + $token)}},
+      {text: "🎙️\nVoice", web_app: {url: ("https://cpc.claude.do/#voice&token=" + $token)}},
+      {text: "📝\nScrum"}
+    ]],
+    resize_keyboard: true,
+    is_persistent: true
+  }'
+}

--- a/hooks/lib/launcher-keyboard.sh
+++ b/hooks/lib/launcher-keyboard.sh
@@ -12,7 +12,7 @@ build_cpc_auth_token() {
 
   now=$(date +%s)
   jwt_header=$(printf '%s' '{"alg":"HS256","typ":"JWT"}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
-  jwt_payload=$(printf '{"sub":"%s","iat":%s,"exp":%s}' "$chat_id" "$now" "$((now + 604800))" | base64 -w0 | tr '+/' '-_' | tr -d '=')
+  jwt_payload=$(jq -cn --arg sub "$chat_id" --arg iat "$now" --arg exp "$((now + 7 * 24 * 60 * 60))" '{sub: $sub, iat: ($iat|tonumber), exp: ($exp|tonumber)}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
   jwt_signature=$(printf '%s' "${jwt_header}.${jwt_payload}" | openssl dgst -sha256 -hmac "${bot_token}" -binary | base64 -w0 | tr '+/' '-_' | tr -d '=')
 
   printf '%s' "${jwt_header}.${jwt_payload}.${jwt_signature}"

--- a/hooks/voice-hook
+++ b/hooks/voice-hook
@@ -84,6 +84,15 @@ echo "Sending Telegram reply and outputting JSON" >> "$LOG"
 
 # Send transcription as a quoted reply to the user on Telegram
 if [ -n "$CHAT_ID" ] && [ -n "$MSG_ID" ]; then
+  # Generate a fresh JWT for launcher keyboard web_app URLs
+  # (matches launcher-hook / actions-hook).
+  JWT_SECRET="${BOTTOKEN}"
+  JWT_HEADER=$(echo -n '{"alg":"HS256","typ":"JWT"}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
+  JWT_PAYLOAD=$(echo -n "{\"sub\":\"${CHAT_ID}\",\"iat\":$(date +%s),\"exp\":$(($(date +%s) + 604800))}" | base64 -w0 | tr '+/' '-_' | tr -d '=')
+  JWT_SIGNATURE=$(echo -n "${JWT_HEADER}.${JWT_PAYLOAD}" | openssl dgst -sha256 -hmac "${JWT_SECRET}" -binary | base64 -w0 | tr '+/' '-_' | tr -d '=')
+  CPC_AUTH_TOKEN="${JWT_HEADER}.${JWT_PAYLOAD}.${JWT_SIGNATURE}"
+
+  LAUNCHER="{\"keyboard\":[[{\"text\":\"⚡️\\nActions\"},{\"text\":\"📱\\nDevelop\",\"web_app\":{\"url\":\"https://cpc.claude.do/dev/?token=${CPC_AUTH_TOKEN}\"}},{\"text\":\"🎙️\\nVoice\",\"web_app\":{\"url\":\"https://cpc.claude.do/#voice&token=${CPC_AUTH_TOKEN}\"}},{\"text\":\"📝\\nScrum\"}]],\"resize_keyboard\":true,\"is_persistent\":true}"
   # Per Gemini review: the transcription is interpolated into an HTML-formatted
   # Telegram message, so raw `<`, `>`, `&` in the transcript would break parsing
   # (or enable tag injection). Escape `&` FIRST so the later `<`/`>` substitutions
@@ -100,7 +109,8 @@ if [ -n "$CHAT_ID" ] && [ -n "$MSG_ID" ]; then
       --arg chat_id "$CHAT_ID" \
       --arg reply_to "$MSG_ID" \
       --arg text "$QUOTED" \
-      '{chat_id: $chat_id, reply_to_message_id: ($reply_to | tonumber), text: $text, parse_mode: "HTML", disable_notification: true}'
+      --argjson reply_markup "$LAUNCHER" \
+      '{chat_id: $chat_id, reply_to_message_id: ($reply_to | tonumber), text: $text, parse_mode: "HTML", disable_notification: true, reply_markup: $reply_markup}'
     )" > /dev/null 2>&1 || true
 fi
 

--- a/hooks/voice-hook
+++ b/hooks/voice-hook
@@ -42,6 +42,8 @@ if [ -z "$BOTTOKEN" ]; then
   exit 0
 fi
 
+. "$(dirname "$(readlink -f "$0")")/lib/launcher-keyboard.sh"
+
 # Load OpenAI key
 eval "$(grep OPENAI_API_KEY /home/claude/.secrets/openai.env 2>/dev/null | head -1)"
 export OPENAI_API_KEY
@@ -84,15 +86,7 @@ echo "Sending Telegram reply and outputting JSON" >> "$LOG"
 
 # Send transcription as a quoted reply to the user on Telegram
 if [ -n "$CHAT_ID" ] && [ -n "$MSG_ID" ]; then
-  # Generate a fresh JWT for launcher keyboard web_app URLs
-  # (matches launcher-hook / actions-hook).
-  JWT_SECRET="${BOTTOKEN}"
-  JWT_HEADER=$(echo -n '{"alg":"HS256","typ":"JWT"}' | base64 -w0 | tr '+/' '-_' | tr -d '=')
-  JWT_PAYLOAD=$(echo -n "{\"sub\":\"${CHAT_ID}\",\"iat\":$(date +%s),\"exp\":$(($(date +%s) + 604800))}" | base64 -w0 | tr '+/' '-_' | tr -d '=')
-  JWT_SIGNATURE=$(echo -n "${JWT_HEADER}.${JWT_PAYLOAD}" | openssl dgst -sha256 -hmac "${JWT_SECRET}" -binary | base64 -w0 | tr '+/' '-_' | tr -d '=')
-  CPC_AUTH_TOKEN="${JWT_HEADER}.${JWT_PAYLOAD}.${JWT_SIGNATURE}"
-
-  LAUNCHER="{\"keyboard\":[[{\"text\":\"⚡️\\nActions\"},{\"text\":\"📱\\nDevelop\",\"web_app\":{\"url\":\"https://cpc.claude.do/dev/?token=${CPC_AUTH_TOKEN}\"}},{\"text\":\"🎙️\\nVoice\",\"web_app\":{\"url\":\"https://cpc.claude.do/#voice&token=${CPC_AUTH_TOKEN}\"}},{\"text\":\"📝\\nScrum\"}]],\"resize_keyboard\":true,\"is_persistent\":true}"
+  LAUNCHER=$(build_launcher_reply_markup "$CHAT_ID" "$BOTTOKEN")
   # Per Gemini review: the transcription is interpolated into an HTML-formatted
   # Telegram message, so raw `<`, `>`, `&` in the transcript would break parsing
   # (or enable tag injection). Escape `&` FIRST so the later `<`/`>` substitutions


### PR DESCRIPTION
## Summary

During voice-note-heavy iPhone UAT, the Telegram reply keyboard can hide mid-session and stay hidden until Telegram is force-quit. The likely trigger is the voice transcription reply path posting a message without reasserting the launcher keyboard, combined with the fact that launcher-hook only restores the keyboard at session start.

## Commit strategy

This PR keeps the approved two-commit shape:

1. `fix(telegram): reattach launcher keyboard on voice transcriptions`
2. `refactor(telegram): share launcher keyboard builder across hooks`

## Manual iPhone verification

1. Force-quit Telegram once to reset the client keyboard state, then reopen the chat.
2. Start or resume the Claude session and confirm the four launcher buttons are visible.
3. Send one short voice note and confirm the transcription reply appears as a quoted message while the launcher keyboard remains visible.
4. Tap `📱 Develop` and `🎙️ Voice` and confirm both mini app routes still open and authenticate correctly.
5. Send 10 more voice notes interleaved with ordinary Claude replies and at least two `⚡️ Actions` flows, and confirm the launcher never disappears.
6. Background Telegram, lock and unlock the phone, reopen the chat, and send one more voice note; confirm the launcher is still present.

## Plan doc

- `/home/claude/claudes-world/tmp/20260409-reply-keyboard-fix-implementation-plan.md`
