### PR TITLE
chore: add .world/ports.yml for port-for allocation (ADR 0003)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .env
 *.pyc
 __pycache__/
+
+# Worktree-local port allocations from port-for (ADR 0003)
+.world/ports.lock

--- a/.world/ports.yml
+++ b/.world/ports.yml
@@ -1,0 +1,13 @@
+# Port declarations for port-for allocation (ADR 0003).
+#
+# toolbox has no port-binding services yet — it is a collection of
+# shell scripts and Claude Code hooks (md-speak, tg-sanitize,
+# transcribe, speak, gen-image, world-init, tag-mp3, openai-usage,
+# plus hooks/). None of these bind TCP ports.
+#
+# This file exists so that `port-for --init` treats the repo as
+# migrated (empty `purposes` list → nothing to allocate, no warning
+# about a missing config) and so future services added to toolbox can
+# be declared here alongside the existing pattern from CPC and inbox.
+repo: toolbox
+purposes: []


### PR DESCRIPTION
## Summary
- Declares an empty `.world/ports.yml` for toolbox so `port-for --init` treats the repo as migrated per ADR 0003.
- Gitignores `.world/ports.lock` ahead of any lock files being generated.

## Why empty?
toolbox is a collection of shell scripts and Claude Code hooks (md-speak, tg-sanitize, transcribe, speak, gen-image, world-init, tag-mp3, openai-usage, plus `hooks/`). None of these bind TCP ports, so there are no purposes to declare today. Future port-binding services can be added to the `purposes:` list alongside the pattern established in CPC and inbox.

## Test plan
- [x] `/home/claude/bin/port-for --init /home/claude/code/toolbox` → exits 0, writes a `.world/ports.lock` with an empty `ports: {}` map, registry stays clean. Released with `--release-worktree` after the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)