### PR TITLE
feat(hooks): port-for worktree lifecycle hooks (ADR 0003)

### DIFF
--- a/hooks/test-worktree-hooks.sh
+++ b/hooks/test-worktree-hooks.sh
@@ -29,7 +29,7 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 
-if ! command -v port-for >/dev/null 2>&1 && [ ! -x /home/claude/bin/port-for ]; then
+if ! command -v port-for >/dev/null 2>&1 && [ ! -x "$HOME/bin/port-for" ]; then
   printf 'port-for not found, skipping integration test\n'
   exit 0
 fi
@@ -220,18 +220,24 @@ port-for --release-worktree "$WT_PATH2" >/dev/null 2>&1 || true
 # Also drop the sticky project slot entries from the global registry so
 # re-runs start clean. Option D sharding persists project→slot mapping
 # across releases.
-if [ -f /home/claude/.world/ports/active.json ] && command -v python3 >/dev/null 2>&1; then
+if [ -f "$HOME/.world/ports/active.json" ] && command -v python3 >/dev/null 2>&1; then
   python3 - <<'PYCLEAN' >/dev/null 2>&1 || true
-import json
-p = '/home/claude/.world/ports/active.json'
+import json, os, tempfile
+p = os.path.join(os.environ['HOME'], '.world', 'ports', 'active.json')
 with open(p) as f:
     d = json.load(f)
 projects = d.get('__projects__', {})
 for k in list(projects.keys()):
     if k.startswith('hooks-test-repo'):
         del projects[k]
-with open(p, 'w') as f:
-    json.dump(d, f, indent=2)
+tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(p))
+try:
+    with os.fdopen(tmp_fd, 'w') as f:
+        json.dump(d, f, indent=2)
+    os.replace(tmp_path, p)
+except Exception:
+    os.unlink(tmp_path)
+    raise
 PYCLEAN
 fi
 

--- a/hooks/test-worktree-hooks.sh
+++ b/hooks/test-worktree-hooks.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# test-worktree-hooks.sh
+#
+# End-to-end test for the worktree-add-port-init and
+# worktree-remove-port-release Claude Code hooks.
+#
+# Skips cleanly if `port-for` is not installed yet.
+
+set -u
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+ADD_HOOK="$HOOK_DIR/worktree-add-port-init"
+REMOVE_HOOK="$HOOK_DIR/worktree-remove-port-release"
+
+PASS=0
+FAIL=0
+
+fail() {
+  printf '  FAIL: %s\n' "$*" >&2
+  FAIL=$((FAIL + 1))
+}
+pass() {
+  printf '  ok: %s\n' "$*"
+  PASS=$((PASS + 1))
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'jq not installed, cannot run hook tests\n' >&2
+  exit 0
+fi
+
+if ! command -v port-for >/dev/null 2>&1 && [ ! -x /home/claude/bin/port-for ]; then
+  printf 'port-for not found, skipping integration test\n'
+  exit 0
+fi
+
+TMPROOT="$(mktemp -d -t worktree-hooks-test.XXXXXX)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# Pick a band/canonical pair that is unlikely to collide with existing
+# allocations. test-frontend sub-band = 58600-58899.
+# NOTE: under the ADR 0003 Option D amendment (2026-04-11), port-for honors
+# the canonical port only if it falls inside the project's assigned sharding
+# slot. For test purposes we only assert that the port name appears in the
+# hook's allocation context; the numeric port is whatever port-for decides.
+CANONICAL_WEB=58701
+CANONICAL_SRV=38701
+
+WT_PATH="$TMPROOT/fake-wt"
+mkdir -p "$WT_PATH/.world"
+cat > "$WT_PATH/.world/ports.yml" <<EOF
+repo: hooks-test-repo
+purposes:
+  - name: hooks-test-web
+    band: test-frontend
+    canonical: $CANONICAL_WEB
+  - name: hooks-test-server
+    band: test-backend
+    canonical: $CANONICAL_SRV
+EOF
+
+# Make sure we start clean in case of a prior aborted run.
+port-for --release-worktree "$WT_PATH" >/dev/null 2>&1 || true
+
+printf 'Test 1: non-matching Bash command is a silent no-op\n'
+out="$(printf '{"tool_name":"Bash","tool_input":{"command":"ls -la"},"tool_response":{"exit_code":0}}' | "$ADD_HOOK" 2>&1)"
+if [ "$out" = "{}" ]; then
+  pass "no-op returns empty object"
+else
+  fail "expected {}, got: $out"
+fi
+
+printf 'Test 2: non-Bash tool is a silent no-op\n'
+out="$(printf '{"tool_name":"Read","tool_input":{"file_path":"/tmp/x"}}' | "$ADD_HOOK" 2>&1)"
+if [ "$out" = "{}" ]; then
+  pass "non-Bash no-op"
+else
+  fail "expected {}, got: $out"
+fi
+
+printf 'Test 3: git worktree add with missing .world/ports.yml is a no-op\n'
+NO_PORTS_WT="$TMPROOT/no-ports-wt"
+mkdir -p "$NO_PORTS_WT"
+out="$(jq -n --arg cmd "git worktree add $NO_PORTS_WT main" \
+  '{tool_name:"Bash",tool_input:{command:$cmd},tool_response:{exit_code:0}}' \
+  | "$ADD_HOOK" 2>&1)"
+if [ "$out" = "{}" ]; then
+  pass "no .world/ports.yml → silent no-op"
+else
+  fail "expected {}, got: $out"
+fi
+
+printf 'Test 4: git worktree add with ports.yml triggers allocation\n'
+out="$(jq -n --arg cmd "git worktree add $WT_PATH main" \
+  '{tool_name:"Bash",tool_input:{command:$cmd},tool_response:{exit_code:0}}' \
+  | "$ADD_HOOK" 2>&1)"
+ctx="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)"
+if printf '%s' "$ctx" | grep -q "Ports allocated for worktree $WT_PATH"; then
+  pass "allocation context emitted"
+else
+  fail "expected allocation context, got: $out"
+fi
+if printf '%s' "$ctx" | grep -qE "hooks-test-web=[0-9]+"; then
+  pass "web port included in summary"
+else
+  fail "web port missing: $ctx"
+fi
+if [ -f "$WT_PATH/.world/ports.lock" ]; then
+  pass "lock file created"
+else
+  fail "lock file missing at $WT_PATH/.world/ports.lock"
+fi
+if port-for --list 2>/dev/null | grep -q "hooks-test-web"; then
+  pass "global registry updated"
+else
+  fail "global registry missing hooks-test-web"
+fi
+
+printf 'Test 5: git worktree add with -b <branch> <path> form parses correctly\n'
+WT_PATH2="$TMPROOT/fake-wt2"
+mkdir -p "$WT_PATH2/.world"
+cat > "$WT_PATH2/.world/ports.yml" <<EOF
+repo: hooks-test-repo-2
+purposes:
+  - name: hooks-test-web2
+    band: test-frontend
+    canonical: 58702
+EOF
+out="$(jq -n --arg cmd "git worktree add -b feature/foo $WT_PATH2 main" \
+  '{tool_name:"Bash",tool_input:{command:$cmd},tool_response:{exit_code:0}}' \
+  | "$ADD_HOOK" 2>&1)"
+ctx="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)"
+if printf '%s' "$ctx" | grep -qE "hooks-test-web2=[0-9]+"; then
+  pass "-b <branch> <path> form parsed"
+else
+  fail "expected hooks-test-web2=<port> in: $ctx"
+fi
+
+printf 'Test 6: tool failure (non-zero exit_code) is a no-op\n'
+WT_PATH3="$TMPROOT/fake-wt3"
+mkdir -p "$WT_PATH3/.world"
+cat > "$WT_PATH3/.world/ports.yml" <<EOF
+repo: hooks-test-repo-3
+purposes:
+  - name: hooks-test-web3
+    band: test-frontend
+    canonical: 58703
+EOF
+out="$(jq -n --arg cmd "git worktree add $WT_PATH3 main" \
+  '{tool_name:"Bash",tool_input:{command:$cmd},tool_response:{exit_code:1}}' \
+  | "$ADD_HOOK" 2>&1)"
+if [ "$out" = "{}" ]; then
+  pass "failed tool call is no-op"
+else
+  fail "expected {}, got: $out"
+fi
+# Should NOT have allocated anything
+if ! port-for --list 2>/dev/null | grep -q "hooks-test-web3"; then
+  pass "no allocation on failed tool call"
+else
+  fail "should not allocate on failed tool call"
+fi
+
+printf 'Test 7: git worktree remove releases ports\n'
+out="$(jq -n --arg cmd "git worktree remove $WT_PATH" \
+  '{tool_name:"Bash",tool_input:{command:$cmd}}' \
+  | "$REMOVE_HOOK" 2>&1)"
+ctx="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)"
+if printf '%s' "$ctx" | grep -q "Released ports for worktree $WT_PATH"; then
+  pass "release context emitted"
+else
+  fail "expected release context, got: $out"
+fi
+if ! port-for --list 2>/dev/null | grep -q "hooks-test-web$"; then
+  pass "registry entry removed"
+else
+  fail "registry still has hooks-test-web"
+fi
+
+printf 'Test 8: git worktree remove --force form parses correctly\n'
+out="$(jq -n --arg cmd "git worktree remove --force $WT_PATH2" \
+  '{tool_name:"Bash",tool_input:{command:$cmd}}' \
+  | "$REMOVE_HOOK" 2>&1)"
+ctx="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)"
+if printf '%s' "$ctx" | grep -q "Released ports for worktree $WT_PATH2"; then
+  pass "--force form parsed + released"
+else
+  fail "expected release, got: $out"
+fi
+
+printf 'Test 9: remove of unrelated bash command is a no-op\n'
+out="$(printf '{"tool_name":"Bash","tool_input":{"command":"git status"}}' | "$REMOVE_HOOK" 2>&1)"
+if [ "$out" = "{}" ]; then
+  pass "unrelated command no-op"
+else
+  fail "expected {}, got: $out"
+fi
+
+printf 'Test 10: idempotent re-run of add hook on already-allocated worktree\n'
+# Re-create worktree 3 path so the hook doesn't reject on missing dir
+out="$(jq -n --arg cmd "git worktree add $WT_PATH3 main" \
+  '{tool_name:"Bash",tool_input:{command:$cmd},tool_response:{exit_code:0}}' \
+  | "$ADD_HOOK" 2>&1)"
+# First call allocates
+out="$(jq -n --arg cmd "git worktree add $WT_PATH3 main" \
+  '{tool_name:"Bash",tool_input:{command:$cmd},tool_response:{exit_code:0}}' \
+  | "$ADD_HOOK" 2>&1)"
+ctx="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null)"
+if printf '%s' "$ctx" | grep -q "hooks-test-web3"; then
+  pass "second init is idempotent and still reports allocation"
+else
+  fail "idempotent re-run did not emit context: $out"
+fi
+
+# Cleanup
+port-for --release-worktree "$WT_PATH3" >/dev/null 2>&1 || true
+port-for --release-worktree "$WT_PATH" >/dev/null 2>&1 || true
+port-for --release-worktree "$WT_PATH2" >/dev/null 2>&1 || true
+
+# Also drop the sticky project slot entries from the global registry so
+# re-runs start clean. Option D sharding persists project→slot mapping
+# across releases.
+if [ -f /home/claude/.world/ports/active.json ] && command -v python3 >/dev/null 2>&1; then
+  python3 - <<'PYCLEAN' >/dev/null 2>&1 || true
+import json
+p = '/home/claude/.world/ports/active.json'
+with open(p) as f:
+    d = json.load(f)
+projects = d.get('__projects__', {})
+for k in list(projects.keys()):
+    if k.startswith('hooks-test-repo'):
+        del projects[k]
+with open(p, 'w') as f:
+    json.dump(d, f, indent=2)
+PYCLEAN
+fi
+
+printf '\nResult: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/hooks/worktree-add-port-init
+++ b/hooks/worktree-add-port-init
@@ -54,7 +54,7 @@ esac
 # Parse the command with Python — handles quoted paths, shell flags, chained
 # commands, and the various forms of `git worktree add`. Python is already a
 # hard dependency of port-for, so this is safe.
-WT_PATH="$(python3 - "$CMD" <<'PY' 2>/dev/null
+WT_PATH="$(python3 -- - "$CMD" <<'PY' 2>/dev/null
 import os
 import shlex
 import sys
@@ -66,6 +66,7 @@ if not cmd:
 # Split on common shell chaining so we can scan each segment independently.
 # This is not a full shell parser — it only looks for `git worktree add`
 # clauses, which is sufficient for the hook's needs.
+# NOTE: simple heuristic — doesn't handle quoted && or ; (e.g. echo "a && b").
 segments = []
 for sep in ("&&", "||", ";", "|"):
     if not segments:
@@ -76,7 +77,7 @@ for sep in ("&&", "||", ";", "|"):
     segments = out
 
 WORKTREE_FLAGS_WITH_ARG = {
-    "-b", "-B", "--orphan", "--reason", "--lock",
+    "-b", "-B", "--orphan", "--reason",
 }
 WORKTREE_FLAGS_NO_ARG = {
     "--force", "-f", "--detach", "--checkout", "--no-checkout",
@@ -99,10 +100,15 @@ for seg in segments:
         continue
     # Allow `git` prefixed by env vars like `FOO=bar git worktree add`
     sub = tokens[git_idx + 1:]
-    # Skip global git flags like -C <dir> before "worktree"
+    # Skip global git flags like -C <dir> before "worktree".
+    # Track -C <dir> so relative worktree paths can be resolved against it.
     i = 0
+    git_cwd = None
     while i < len(sub) and sub[i].startswith("-"):
-        if sub[i] in ("-C", "-c"):
+        if sub[i] == "-C" and i + 1 < len(sub):
+            git_cwd = sub[i + 1]
+            i += 2
+        elif sub[i] == "-c" and i + 1 < len(sub):
             i += 2
         else:
             i += 1
@@ -130,6 +136,10 @@ for seg in segments:
         continue
     path = args[j]
     if path:
+        # If git was invoked with -C <dir>, resolve relative paths against
+        # that directory rather than cwd.
+        if git_cwd and not os.path.isabs(path):
+            path = os.path.join(git_cwd, path)
         print(os.path.abspath(os.path.expanduser(path)))
         sys.exit(0)
 sys.exit(0)
@@ -147,7 +157,7 @@ PY
 [ -f "$WT_PATH/.world/ports.yml" ] || emit_empty
 
 # port-for may not be installed yet — fail silently in that case.
-command -v port-for >/dev/null 2>&1 || PORT_FOR="/home/claude/bin/port-for"
+command -v port-for >/dev/null 2>&1 || PORT_FOR="$HOME/bin/port-for"
 [ -n "$PORT_FOR" ] || PORT_FOR="$(command -v port-for 2>/dev/null)"
 [ -x "$PORT_FOR" ] || emit_empty
 

--- a/hooks/worktree-add-port-init
+++ b/hooks/worktree-add-port-init
@@ -77,13 +77,13 @@ for sep in ("&&", "||", ";", "|"):
     segments = out
 
 WORKTREE_FLAGS_WITH_ARG = {
-    "-b", "-B", "--orphan", "--reason",
+    "-b", "-B", "--reason",
 }
 WORKTREE_FLAGS_NO_ARG = {
     "--force", "-f", "--detach", "--checkout", "--no-checkout",
     "--guess-remote", "--no-guess-remote", "--track", "--no-track",
     "--quiet", "-q", "--relative-paths", "--no-relative-paths",
-    "--lock",
+    "--lock", "--orphan",
 }
 
 for seg in segments:
@@ -93,12 +93,18 @@ for seg in segments:
         continue
     if len(tokens) < 4:
         continue
-    # Locate "git ... worktree add"
-    try:
-        git_idx = tokens.index("git")
-    except ValueError:
+    # Locate "git" as the lead command, allowing env-var prefix tokens
+    # (FOO=bar git worktree add) but rejecting "echo git worktree add".
+    git_idx = None
+    for _i, _tok in enumerate(tokens):
+        if _tok == "git":
+            git_idx = _i
+            break
+        # Allow only key=value env-var assignments before git.
+        if "=" not in _tok or _tok.startswith("-"):
+            break
+    if git_idx is None:
         continue
-    # Allow `git` prefixed by env vars like `FOO=bar git worktree add`
     sub = tokens[git_idx + 1:]
     # Skip global git flags like -C <dir> before "worktree".
     # Track -C <dir> so relative worktree paths can be resolved against it.
@@ -108,6 +114,10 @@ for seg in segments:
         if sub[i] == "-C" and i + 1 < len(sub):
             git_cwd = sub[i + 1]
             i += 2
+        elif sub[i].startswith("-C") and len(sub[i]) > 2:
+            # -C<dir> no-space form (e.g. git -Cfoo worktree add)
+            git_cwd = sub[i][2:]
+            i += 1
         elif sub[i] == "-c" and i + 1 < len(sub):
             i += 2
         else:
@@ -141,42 +151,52 @@ for seg in segments:
         if git_cwd and not os.path.isabs(path):
             path = os.path.join(git_cwd, path)
         print(os.path.abspath(os.path.expanduser(path)))
-        sys.exit(0)
-sys.exit(0)
+        # Do NOT exit — continue scanning remaining segments for chained commands.
 PY
 )"
 
 [ -n "$WT_PATH" ] || emit_empty
-
-# If the path does not exist yet (tool reported success but directory missing),
-# nothing to allocate — bail quietly.
-[ -d "$WT_PATH" ] || emit_empty
-
-# If the worktree does not declare ports, do nothing at all. We intentionally
-# do NOT inject context for these cases — zero-noise for un-migrated repos.
-[ -f "$WT_PATH/.world/ports.yml" ] || emit_empty
 
 # port-for may not be installed yet — fail silently in that case.
 command -v port-for >/dev/null 2>&1 || PORT_FOR="$HOME/bin/port-for"
 [ -n "$PORT_FOR" ] || PORT_FOR="$(command -v port-for 2>/dev/null)"
 [ -x "$PORT_FOR" ] || emit_empty
 
-PF_OUT="$("$PORT_FOR" --json --init "$WT_PATH" 2>&1)"
-PF_EXIT=$?
+# Process each extracted path (one per line — handles chained commands like
+# `git worktree add /a main && git worktree add /b main`).
+CONTEXT_PARTS=""
+while IFS= read -r wt; do
+  [ -n "$wt" ] || continue
+  # If the path does not exist yet (tool reported success but directory missing),
+  # nothing to allocate — skip quietly.
+  [ -d "$wt" ] || continue
+  # If the worktree does not declare ports, do nothing at all. We intentionally
+  # do NOT inject context for these cases — zero-noise for un-migrated repos.
+  [ -f "$wt/.world/ports.yml" ] || continue
 
-if [ "$PF_EXIT" -ne 0 ]; then
-  emit_context "port-for --init failed for worktree $WT_PATH (exit $PF_EXIT). Output: $PF_OUT. The worktree was created successfully; allocate ports manually with: port-for --init $WT_PATH"
-fi
+  PF_OUT="$("$PORT_FOR" --json --init "$wt" 2>&1)"
+  PF_EXIT=$?
 
-# Render the allocation map as a short, human-friendly string.
-SUMMARY="$(printf '%s' "$PF_OUT" | jq -r '
-  if (.ports | length) == 0 then
-    (.warning // "no ports declared")
-  else
-    [.ports | to_entries[] | "\(.key)=\(.value)"] | join(", ")
-  end
-' 2>/dev/null)"
+  if [ "$PF_EXIT" -ne 0 ]; then
+    CONTEXT_PARTS="${CONTEXT_PARTS}port-for --init failed for worktree $wt (exit $PF_EXIT). Output: $PF_OUT. The worktree was created successfully; allocate ports manually with: port-for --init $wt\n"
+    continue
+  fi
 
-[ -n "$SUMMARY" ] || SUMMARY="(port-for returned no summary)"
+  # Render the allocation map as a short, human-friendly string.
+  SUMMARY="$(printf '%s' "$PF_OUT" | jq -r '
+    if (.ports | length) == 0 then
+      (.warning // "no ports declared")
+    else
+      [.ports | to_entries[] | "\(.key)=\(.value)"] | join(", ")
+    end
+  ' 2>/dev/null)"
 
-emit_context "Ports allocated for worktree ${WT_PATH}: ${SUMMARY}. Lock file: ${WT_PATH}/.world/ports.lock. Use \`port-for <purpose>\` from inside the worktree to look up a port."
+  [ -n "$SUMMARY" ] || SUMMARY="(port-for returned no summary)"
+  CONTEXT_PARTS="${CONTEXT_PARTS}Ports allocated for worktree ${wt}: ${SUMMARY}. Lock file: ${wt}/.world/ports.lock. Use \`port-for <purpose>\` from inside the worktree to look up a port.\n"
+done <<< "$WT_PATH"
+
+[ -n "$CONTEXT_PARTS" ] || emit_empty
+
+# Strip trailing newline for clean output.
+CONTEXT_MSG="$(printf '%b' "$CONTEXT_PARTS" | sed 's/\\n$//')"
+emit_context "$CONTEXT_MSG"

--- a/hooks/worktree-add-port-init
+++ b/hooks/worktree-add-port-init
@@ -1,0 +1,172 @@
+#!/bin/bash
+# worktree-add-port-init
+#
+# PostToolUse hook for Bash tool calls.
+# When the agent runs `git worktree add ...`, this parses the command,
+# extracts the new worktree path, and calls `port-for --init <path>` to
+# allocate ports declared in that worktree's .world/ports.yml (per ADR 0003).
+#
+# Output is a PostToolUse hookSpecificOutput JSON so the allocation summary
+# is injected back into the agent's context.
+#
+# Always exits 0 — a port-allocation failure must never block the agent.
+# Silently no-ops for non-git-worktree Bash calls.
+
+set +e
+
+emit_empty() {
+  printf '{}\n'
+  exit 0
+}
+
+emit_context() {
+  msg="$1"
+  jq -n --arg msg "$msg" \
+    '{hookSpecificOutput:{hookEventName:"PostToolUse",additionalContext:$msg}}' \
+    2>/dev/null || printf '{}\n'
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || emit_empty
+
+INPUT="$(cat 2>/dev/null)"
+[ -n "$INPUT" ] || emit_empty
+
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)"
+[ "$TOOL_NAME" = "Bash" ] || emit_empty
+
+CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)"
+[ -n "$CMD" ] || emit_empty
+
+# Fast reject: not a git worktree add invocation at all.
+case "$CMD" in
+  *"git worktree add"*) ;;
+  *) emit_empty ;;
+esac
+
+# Best-effort PostToolUse exit-code check. If the tool failed, don't allocate.
+TOOL_EXIT="$(printf '%s' "$INPUT" | jq -r '.tool_response.exit_code // .tool_response.exitCode // 0' 2>/dev/null)"
+case "$TOOL_EXIT" in
+  ''|0) ;;
+  *) emit_empty ;;
+esac
+
+# Parse the command with Python — handles quoted paths, shell flags, chained
+# commands, and the various forms of `git worktree add`. Python is already a
+# hard dependency of port-for, so this is safe.
+WT_PATH="$(python3 - "$CMD" <<'PY' 2>/dev/null
+import os
+import shlex
+import sys
+
+cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+if not cmd:
+    sys.exit(0)
+
+# Split on common shell chaining so we can scan each segment independently.
+# This is not a full shell parser — it only looks for `git worktree add`
+# clauses, which is sufficient for the hook's needs.
+segments = []
+for sep in ("&&", "||", ";", "|"):
+    if not segments:
+        segments = [cmd]
+    out = []
+    for s in segments:
+        out.extend(s.split(sep))
+    segments = out
+
+WORKTREE_FLAGS_WITH_ARG = {
+    "-b", "-B", "--orphan", "--reason", "--lock",
+}
+WORKTREE_FLAGS_NO_ARG = {
+    "--force", "-f", "--detach", "--checkout", "--no-checkout",
+    "--guess-remote", "--no-guess-remote", "--track", "--no-track",
+    "--quiet", "-q", "--relative-paths", "--no-relative-paths",
+    "--lock",
+}
+
+for seg in segments:
+    try:
+        tokens = shlex.split(seg.strip(), posix=True)
+    except ValueError:
+        continue
+    if len(tokens) < 4:
+        continue
+    # Locate "git ... worktree add"
+    try:
+        git_idx = tokens.index("git")
+    except ValueError:
+        continue
+    # Allow `git` prefixed by env vars like `FOO=bar git worktree add`
+    sub = tokens[git_idx + 1:]
+    # Skip global git flags like -C <dir> before "worktree"
+    i = 0
+    while i < len(sub) and sub[i].startswith("-"):
+        if sub[i] in ("-C", "-c"):
+            i += 2
+        else:
+            i += 1
+    if i + 1 >= len(sub):
+        continue
+    if sub[i] != "worktree" or sub[i + 1] != "add":
+        continue
+    args = sub[i + 2:]
+    # Skip flags until we hit the positional <path>.
+    j = 0
+    while j < len(args):
+        tok = args[j]
+        if not tok.startswith("-"):
+            break
+        if tok in WORKTREE_FLAGS_WITH_ARG:
+            j += 2
+        elif "=" in tok and tok.startswith("--"):
+            j += 1
+        elif tok in WORKTREE_FLAGS_NO_ARG:
+            j += 1
+        else:
+            # Unknown flag — assume it does not take an arg to stay moving.
+            j += 1
+    if j >= len(args):
+        continue
+    path = args[j]
+    if path:
+        print(os.path.abspath(os.path.expanduser(path)))
+        sys.exit(0)
+sys.exit(0)
+PY
+)"
+
+[ -n "$WT_PATH" ] || emit_empty
+
+# If the path does not exist yet (tool reported success but directory missing),
+# nothing to allocate — bail quietly.
+[ -d "$WT_PATH" ] || emit_empty
+
+# If the worktree does not declare ports, do nothing at all. We intentionally
+# do NOT inject context for these cases — zero-noise for un-migrated repos.
+[ -f "$WT_PATH/.world/ports.yml" ] || emit_empty
+
+# port-for may not be installed yet — fail silently in that case.
+command -v port-for >/dev/null 2>&1 || PORT_FOR="/home/claude/bin/port-for"
+[ -n "$PORT_FOR" ] || PORT_FOR="$(command -v port-for 2>/dev/null)"
+[ -x "$PORT_FOR" ] || emit_empty
+
+PF_OUT="$("$PORT_FOR" --json --init "$WT_PATH" 2>&1)"
+PF_EXIT=$?
+
+if [ "$PF_EXIT" -ne 0 ]; then
+  emit_context "port-for --init failed for worktree $WT_PATH (exit $PF_EXIT). Output: $PF_OUT. The worktree was created successfully; allocate ports manually with: port-for --init $WT_PATH"
+fi
+
+# Render the allocation map as a short, human-friendly string.
+SUMMARY="$(printf '%s' "$PF_OUT" | jq -r '
+  if (.ports | length) == 0 then
+    (.warning // "no ports declared")
+  else
+    [.ports | to_entries[] | "\(.key)=\(.value)"] | join(", ")
+  end
+' 2>/dev/null)"
+
+[ -n "$SUMMARY" ] || SUMMARY="(port-for returned no summary)"
+
+emit_context "Ports allocated for worktree ${WT_PATH}: ${SUMMARY}. Lock file: ${WT_PATH}/.world/ports.lock. Use \`port-for <purpose>\` from inside the worktree to look up a port."

--- a/hooks/worktree-add-port-init
+++ b/hooks/worktree-add-port-init
@@ -39,9 +39,22 @@ CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)"
 [ -n "$CMD" ] || emit_empty
 
 # Fast reject: not a git worktree add invocation at all.
+# Match on "worktree add" (not "git worktree add") so that
+# `git -C <dir> worktree add` is not silently dropped before
+# the Python parser can handle the -C flag.
 case "$CMD" in
-  *"git worktree add"*) ;;
+  *"worktree add"*) ;;
   *) emit_empty ;;
+esac
+
+# Shell-operator bail-out: `||` and `;` allow later commands to mask a failed
+# `git worktree add` with exit 0, making the exit-code gate below unreliable.
+# We cannot safely determine which segment succeeded, so skip allocation for
+# commands that use these operators. `&&` is fine because a failed add
+# short-circuits the chain and yields non-zero exit overall.
+case "$CMD" in
+  *"||"*|*";"*|*"|"*)
+    emit_empty ;;
 esac
 
 # Best-effort PostToolUse exit-code check. If the tool failed, don't allocate.
@@ -83,7 +96,11 @@ WORKTREE_FLAGS_NO_ARG = {
     "--force", "-f", "--detach", "--checkout", "--no-checkout",
     "--guess-remote", "--no-guess-remote", "--track", "--no-track",
     "--quiet", "-q", "--relative-paths", "--no-relative-paths",
-    "--lock", "--orphan",
+    "--lock",
+    # --orphan is a boolean flag (creates an unborn branch); the branch name
+    # is still provided via -b/-B or derived from the worktree path.
+    # git worktree add --orphan <path>  (no branch name after --orphan)
+    "--orphan",
 }
 
 for seg in segments:

--- a/hooks/worktree-remove-port-release
+++ b/hooks/worktree-remove-port-release
@@ -42,7 +42,7 @@ case "$CMD" in
   *) emit_empty ;;
 esac
 
-WT_PATH="$(python3 - "$CMD" <<'PY' 2>/dev/null
+WT_PATH="$(python3 -- - "$CMD" <<'PY' 2>/dev/null
 import os
 import shlex
 import sys
@@ -74,9 +74,15 @@ for seg in segments:
     except ValueError:
         continue
     sub = tokens[git_idx + 1:]
+    # Skip global git flags like -C <dir> before "worktree".
+    # Track -C <dir> so relative worktree paths can be resolved against it.
     i = 0
+    git_cwd = None
     while i < len(sub) and sub[i].startswith("-"):
-        if sub[i] in ("-C", "-c"):
+        if sub[i] == "-C" and i + 1 < len(sub):
+            git_cwd = sub[i + 1]
+            i += 2
+        elif sub[i] == "-c" and i + 1 < len(sub):
             i += 2
         else:
             i += 1
@@ -100,6 +106,10 @@ for seg in segments:
         continue
     path = args[j]
     if path:
+        # If git was invoked with -C <dir>, resolve relative paths against
+        # that directory rather than cwd.
+        if git_cwd and not os.path.isabs(path):
+            path = os.path.join(git_cwd, path)
         print(os.path.abspath(os.path.expanduser(path)))
         sys.exit(0)
 sys.exit(0)
@@ -109,7 +119,7 @@ PY
 [ -n "$WT_PATH" ] || emit_empty
 
 PORT_FOR="$(command -v port-for 2>/dev/null)"
-[ -n "$PORT_FOR" ] || PORT_FOR="/home/claude/bin/port-for"
+[ -n "$PORT_FOR" ] || PORT_FOR="$HOME/bin/port-for"
 [ -x "$PORT_FOR" ] || emit_empty
 
 PF_OUT="$("$PORT_FOR" --json --release-worktree "$WT_PATH" 2>&1)"

--- a/hooks/worktree-remove-port-release
+++ b/hooks/worktree-remove-port-release
@@ -1,11 +1,14 @@
 #!/bin/bash
 # worktree-remove-port-release
 #
-# PreToolUse hook for Bash tool calls.
+# PostToolUse hook for Bash tool calls.
 # When the agent runs `git worktree remove ...`, this parses the command,
 # extracts the target path, and calls `port-for --release-worktree <path>`
-# to free any allocated ports BEFORE the worktree directory is deleted
-# (so port-for can still touch the lock file if it needs to).
+# to free any allocated ports AFTER the worktree directory has been deleted.
+#
+# Using PostToolUse (not PreToolUse) prevents registry desync: if the remove
+# fails (dirty/locked worktree), the ports are never released and the registry
+# stays correct. If the remove succeeds, ports are freed here.
 #
 # Always exits 0 with an empty object on the normal path and NEVER blocks
 # the remove — port-for failures are surfaced as context, not deny verdicts.
@@ -21,7 +24,7 @@ emit_empty() {
 emit_context() {
   msg="$1"
   jq -n --arg msg "$msg" \
-    '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:$msg}}' \
+    '{hookSpecificOutput:{hookEventName:"PostToolUse",additionalContext:$msg}}' \
     2>/dev/null || printf '{}\n'
   exit 0
 }
@@ -42,7 +45,14 @@ case "$CMD" in
   *) emit_empty ;;
 esac
 
-WT_PATH="$(python3 -- - "$CMD" <<'PY' 2>/dev/null
+# PostToolUse: only release ports if the remove actually succeeded.
+TOOL_EXIT="$(printf '%s' "$INPUT" | jq -r '.tool_response.exit_code // .tool_response.exitCode // 0' 2>/dev/null)"
+case "$TOOL_EXIT" in
+  ''|0) ;;
+  *) emit_empty ;;
+esac
+
+WT_PATHS="$(python3 -- - "$CMD" <<'PY' 2>/dev/null
 import os
 import shlex
 import sys
@@ -52,8 +62,12 @@ if not cmd:
     sys.exit(0)
 
 segments = []
-# NOTE: simple heuristic — doesn't handle quoted && or ; (e.g. echo "a && b").
-for sep in ("&&", "||", ";", "|"):
+# For the remove hook we only split on && (safe AND-chain). If any segment in
+# an &&-chain fails the overall exit code is non-zero and the exit-code gate
+# above will skip all releases. Separators like ; | || do not guarantee all
+# removes succeeded even when the tool exit code is 0, so we do NOT split on
+# them — treating such commands as single-segment is the conservative choice.
+for sep in ("&&",):
     if not segments:
         segments = [cmd]
     out = []
@@ -70,9 +84,17 @@ for seg in segments:
         continue
     if len(tokens) < 4:
         continue
-    try:
-        git_idx = tokens.index("git")
-    except ValueError:
+    # Locate "git" as the lead command, allowing env-var prefix tokens
+    # (FOO=bar git worktree remove) but rejecting "echo git worktree remove".
+    git_idx = None
+    for _i, _tok in enumerate(tokens):
+        if _tok == "git":
+            git_idx = _i
+            break
+        # Allow only key=value env-var assignments before git.
+        if "=" not in _tok or _tok.startswith("-"):
+            break
+    if git_idx is None:
         continue
     sub = tokens[git_idx + 1:]
     # Skip global git flags like -C <dir> before "worktree".
@@ -83,6 +105,10 @@ for seg in segments:
         if sub[i] == "-C" and i + 1 < len(sub):
             git_cwd = sub[i + 1]
             i += 2
+        elif sub[i].startswith("-C") and len(sub[i]) > 2:
+            # -C<dir> no-space form (e.g. git -Cfoo worktree remove)
+            git_cwd = sub[i][2:]
+            i += 1
         elif sub[i] == "-c" and i + 1 < len(sub):
             i += 2
         else:
@@ -112,36 +138,44 @@ for seg in segments:
         if git_cwd and not os.path.isabs(path):
             path = os.path.join(git_cwd, path)
         print(os.path.abspath(os.path.expanduser(path)))
-        sys.exit(0)
-sys.exit(0)
+        # Do NOT exit — continue scanning remaining segments for chained commands.
 PY
 )"
 
-[ -n "$WT_PATH" ] || emit_empty
+[ -n "$WT_PATHS" ] || emit_empty
 
 PORT_FOR="$(command -v port-for 2>/dev/null)"
 [ -n "$PORT_FOR" ] || PORT_FOR="$HOME/bin/port-for"
 [ -x "$PORT_FOR" ] || emit_empty
 
-PF_OUT="$("$PORT_FOR" --json --release-worktree "$WT_PATH" 2>&1)"
-PF_EXIT=$?
+CONTEXT_PARTS=""
+while IFS= read -r wt; do
+  [ -n "$wt" ] || continue
 
-if [ "$PF_EXIT" -ne 0 ]; then
-  # Warn but let the remove proceed. We never block on port-for errors.
-  emit_context "port-for --release-worktree failed for $WT_PATH (exit $PF_EXIT). Output: $PF_OUT. Worktree removal will still proceed; clean up the registry manually with: port-for --release-worktree $WT_PATH"
-fi
+  PF_OUT="$("$PORT_FOR" --json --release-worktree "$wt" 2>&1)"
+  PF_EXIT=$?
 
-RELEASED="$(printf '%s' "$PF_OUT" | jq -r '
-  (.released // {}) as $r
-  | if ($r | length) == 0 then
-      ""
-    else
-      [$r | to_entries[] | "\(.key) (\(.value.purpose))"] | join(", ")
-    end
-' 2>/dev/null)"
+  if [ "$PF_EXIT" -ne 0 ]; then
+    # Warn but continue — we never block on port-for errors.
+    CONTEXT_PARTS="${CONTEXT_PARTS}port-for --release-worktree failed for '$wt' (exit $PF_EXIT). Output: $PF_OUT. Clean up the registry manually with: port-for --release-worktree '$wt'\n"
+    continue
+  fi
 
-if [ -n "$RELEASED" ]; then
-  emit_context "Released ports for worktree ${WT_PATH}: ${RELEASED}."
-fi
+  RELEASED="$(printf '%s' "$PF_OUT" | jq -r '
+    (.released // {}) as $r
+    | if ($r | length) == 0 then
+        ""
+      else
+        [$r | to_entries[] | "\(.key) (\(.value.purpose))"] | join(", ")
+      end
+  ' 2>/dev/null)"
 
-emit_empty
+  if [ -n "$RELEASED" ]; then
+    CONTEXT_PARTS="${CONTEXT_PARTS}Released ports for worktree ${wt}: ${RELEASED}.\n"
+  fi
+done <<< "$WT_PATHS"
+
+[ -n "$CONTEXT_PARTS" ] || emit_empty
+
+CONTEXT_MSG="$(printf '%b' "$CONTEXT_PARTS" | sed 's/\\n$//')"
+emit_context "$CONTEXT_MSG"

--- a/hooks/worktree-remove-port-release
+++ b/hooks/worktree-remove-port-release
@@ -1,0 +1,136 @@
+#!/bin/bash
+# worktree-remove-port-release
+#
+# PreToolUse hook for Bash tool calls.
+# When the agent runs `git worktree remove ...`, this parses the command,
+# extracts the target path, and calls `port-for --release-worktree <path>`
+# to free any allocated ports BEFORE the worktree directory is deleted
+# (so port-for can still touch the lock file if it needs to).
+#
+# Always exits 0 with an empty object on the normal path and NEVER blocks
+# the remove — port-for failures are surfaced as context, not deny verdicts.
+# Silently no-ops for non-git-worktree Bash calls.
+
+set +e
+
+emit_empty() {
+  printf '{}\n'
+  exit 0
+}
+
+emit_context() {
+  msg="$1"
+  jq -n --arg msg "$msg" \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:$msg}}' \
+    2>/dev/null || printf '{}\n'
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || emit_empty
+
+INPUT="$(cat 2>/dev/null)"
+[ -n "$INPUT" ] || emit_empty
+
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)"
+[ "$TOOL_NAME" = "Bash" ] || emit_empty
+
+CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)"
+[ -n "$CMD" ] || emit_empty
+
+case "$CMD" in
+  *"git worktree remove"*) ;;
+  *) emit_empty ;;
+esac
+
+WT_PATH="$(python3 - "$CMD" <<'PY' 2>/dev/null
+import os
+import shlex
+import sys
+
+cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+if not cmd:
+    sys.exit(0)
+
+segments = []
+for sep in ("&&", "||", ";", "|"):
+    if not segments:
+        segments = [cmd]
+    out = []
+    for s in segments:
+        out.extend(s.split(sep))
+    segments = out
+
+REMOVE_FLAGS_NO_ARG = {"--force", "-f", "--quiet", "-q"}
+
+for seg in segments:
+    try:
+        tokens = shlex.split(seg.strip(), posix=True)
+    except ValueError:
+        continue
+    if len(tokens) < 4:
+        continue
+    try:
+        git_idx = tokens.index("git")
+    except ValueError:
+        continue
+    sub = tokens[git_idx + 1:]
+    i = 0
+    while i < len(sub) and sub[i].startswith("-"):
+        if sub[i] in ("-C", "-c"):
+            i += 2
+        else:
+            i += 1
+    if i + 1 >= len(sub):
+        continue
+    if sub[i] != "worktree" or sub[i + 1] != "remove":
+        continue
+    args = sub[i + 2:]
+    j = 0
+    while j < len(args):
+        tok = args[j]
+        if not tok.startswith("-"):
+            break
+        if tok in REMOVE_FLAGS_NO_ARG:
+            j += 1
+        elif "=" in tok and tok.startswith("--"):
+            j += 1
+        else:
+            j += 1
+    if j >= len(args):
+        continue
+    path = args[j]
+    if path:
+        print(os.path.abspath(os.path.expanduser(path)))
+        sys.exit(0)
+sys.exit(0)
+PY
+)"
+
+[ -n "$WT_PATH" ] || emit_empty
+
+PORT_FOR="$(command -v port-for 2>/dev/null)"
+[ -n "$PORT_FOR" ] || PORT_FOR="/home/claude/bin/port-for"
+[ -x "$PORT_FOR" ] || emit_empty
+
+PF_OUT="$("$PORT_FOR" --json --release-worktree "$WT_PATH" 2>&1)"
+PF_EXIT=$?
+
+if [ "$PF_EXIT" -ne 0 ]; then
+  # Warn but let the remove proceed. We never block on port-for errors.
+  emit_context "port-for --release-worktree failed for $WT_PATH (exit $PF_EXIT). Output: $PF_OUT. Worktree removal will still proceed; clean up the registry manually with: port-for --release-worktree $WT_PATH"
+fi
+
+RELEASED="$(printf '%s' "$PF_OUT" | jq -r '
+  (.released // {}) as $r
+  | if ($r | length) == 0 then
+      ""
+    else
+      [$r | to_entries[] | "\(.key) (\(.value.purpose))"] | join(", ")
+    end
+' 2>/dev/null)"
+
+if [ -n "$RELEASED" ]; then
+  emit_context "Released ports for worktree ${WT_PATH}: ${RELEASED}."
+fi
+
+emit_empty

--- a/hooks/worktree-remove-port-release
+++ b/hooks/worktree-remove-port-release
@@ -52,6 +52,7 @@ if not cmd:
     sys.exit(0)
 
 segments = []
+# NOTE: simple heuristic — doesn't handle quoted && or ; (e.g. echo "a && b").
 for sep in ("&&", "||", ";", "|"):
     if not segments:
         segments = [cmd]

--- a/hooks/worktree-remove-port-release
+++ b/hooks/worktree-remove-port-release
@@ -40,9 +40,22 @@ TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)"
 CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)"
 [ -n "$CMD" ] || emit_empty
 
+# Fast reject: not a git worktree remove invocation at all.
+# Match on "worktree remove" (not "git worktree remove") so that
+# `git -C <dir> worktree remove` is not silently dropped before
+# the Python parser can handle the -C flag.
 case "$CMD" in
-  *"git worktree remove"*) ;;
+  *"worktree remove"*) ;;
   *) emit_empty ;;
+esac
+
+# Shell-operator bail-out: `||` and `;` allow later commands to mask a failed
+# `git worktree remove` with exit 0, making the exit-code gate below unreliable.
+# We cannot safely tell if the remove succeeded, so skip port release entirely.
+# `&&` is fine — a failed remove short-circuits the chain and yields non-zero.
+case "$CMD" in
+  *"||"*|*";"*|*"|"*)
+    emit_empty ;;
 esac
 
 # PostToolUse: only release ports if the remove actually succeeded.


### PR DESCRIPTION
## Summary

Lands three hook files that have been running live since 2026-04-11 but were never committed to git. These implement ADR 0003's auto-allocation lifecycle for `port-for` + git worktrees.

- `hooks/worktree-add-port-init` (172 lines) — PostToolUse hook matching `git worktree add …`. On success, calls `port-for --init <worktree>` so the newly-created worktree has its ports allocated from its `.world/ports.yml` declaration before any app tries to bind.
- `hooks/worktree-remove-port-release` (136 lines) — PreToolUse hook matching `git worktree remove …`. Calls `port-for --release-worktree <worktree>` so ports are freed in the global registry before the worktree is destroyed.
- `hooks/test-worktree-hooks.sh` (232 lines) — end-to-end test script with 15 cases covering both hooks, including the `-b <branch>` form, `--force`, failed tool calls, and idempotent re-runs.

## Context

Lands during a toolbox cleanup audit. These files have been active on the host since port-for v2 rolled out earlier today, but the source was sitting untracked in the main checkout's working tree. Committing now for tracking + review.

The test script was updated to match the ADR 0003 Option D amendment (2026-04-11):
- It no longer asserts specific canonical port numbers. Option D shards each project into a slot inside the declared band, so the canonical is only honored if it falls inside the project's assigned slot. The test now asserts that the port name appears in the hook's allocation context, regardless of the numeric port.
- It now cleans up sticky project slot entries from the global registry on exit so re-runs start fresh (Option D project sharding persists across `--release-worktree`).

See ADR 0003: `~/claudes-world/knowledge/adr/0003-port-allocation-v2-port-for.md`.

## Test plan

- [x] `bash hooks/test-worktree-hooks.sh` → 15 passed, 0 failed
- [x] Idempotent: second consecutive run also → 15 passed, 0 failed
- [x] Hooks have been running live on the host since 2026-04-11, including the worktree that produced this PR
