### PR TITLE
feat(share-doc): add --no-audio flag to skip TTS generation

### DIFF
--- a/hooks/share-doc
+++ b/hooks/share-doc
@@ -10,6 +10,13 @@ set -euo pipefail
 TMPDIR="/home/claude/claudes-world/tmp"
 mkdir -p "$TMPDIR"
 
+NO_AUDIO=0
+for arg in "$@"; do
+  if [ "$arg" = "--no-audio" ]; then
+    NO_AUDIO=1
+  fi
+done
+
 INPUT=$(cat)
 
 # Trim leading/trailing whitespace for path detection
@@ -20,11 +27,14 @@ if [ "$(echo "$TRIMMED" | wc -l)" -eq 1 ] && echo "$TRIMMED" | grep -qE '^/.+\.m
   # --- Mode 2: Share existing file ---
   FILEPATH="$TRIMMED"
   TITLE=$(head -1 "$FILEPATH" | sed 's/^#* *//')
-  AUDIOPATH="${FILEPATH%.md}.mp3"
 
-  # Generate audio if it doesn't already exist
-  if [ ! -f "$AUDIOPATH" ] || [ ! -s "$AUDIOPATH" ]; then
-    /home/claude/bin/md-speak --no-describe --out "$AUDIOPATH" "$FILEPATH" 2>/dev/null || true
+  if [ "$NO_AUDIO" -eq 0 ]; then
+    AUDIOPATH="${FILEPATH%.md}.mp3"
+
+    # Generate audio if it doesn't already exist
+    if [ ! -f "$AUDIOPATH" ] || [ ! -s "$AUDIOPATH" ]; then
+      /home/claude/bin/md-speak --no-describe --out "$AUDIOPATH" "$FILEPATH" 2>/dev/null || true
+    fi
   fi
 else
   # --- Mode 1: Create temp file from inline content ---
@@ -48,9 +58,11 @@ else
   echo "" >> "$FILEPATH"
   echo "$BODY" >> "$FILEPATH"
 
-  # Generate audio version
-  AUDIOPATH="${FILEPATH%.md}.mp3"
-  /home/claude/bin/md-speak --no-describe --out "$AUDIOPATH" "$FILEPATH" 2>/dev/null || true
+  if [ "$NO_AUDIO" -eq 0 ]; then
+    # Generate audio version
+    AUDIOPATH="${FILEPATH%.md}.mp3"
+    /home/claude/bin/md-speak --no-describe --out "$AUDIOPATH" "$FILEPATH" 2>/dev/null || true
+  fi
 fi
 
 # Send to Telegram: audio + deep link button
@@ -61,7 +73,7 @@ if [ -n "$BOTTOKEN" ] && [ -n "$CHAT_ID" ]; then
   ENCODED_PATH=$(python3 -c "from urllib.parse import quote; print(quote('${FILEPATH}'))")
   DEEP_URL="https://cpc.claude.do/#file=${ENCODED_PATH}"
 
-  if [ -f "$AUDIOPATH" ] && [ -s "$AUDIOPATH" ]; then
+  if [ "$NO_AUDIO" -eq 0 ] && [ -n "${AUDIOPATH:-}" ] && [ -f "$AUDIOPATH" ] && [ -s "$AUDIOPATH" ]; then
     # Send audio with inline keyboard button for deep link
     curl -s -X POST "https://api.telegram.org/bot${BOTTOKEN}/sendAudio" \
       -F "chat_id=${CHAT_ID}" \


### PR DESCRIPTION
## Summary

Adds a `--no-audio` flag to `share-doc` that skips `md-speak` invocation and forces the plain `sendMessage` branch (text + inline keyboard deep link).

Useful for quick doc shares where:
- The ~10s TTS generation delay isn't wanted
- The ~50KB audio payload is unnecessary
- You just want to hand off a deep link to a doc

## Behavior

| Flag | Behavior |
|------|----------|
| absent (default) | unchanged — audio generated, sendAudio used |
| `--no-audio` | md-speak skipped, AUDIOPATH never assigned, sendMessage branch always taken |

## Implementation

7-line flag parser at the top, then `if [ "$NO_AUDIO" -eq 0 ]` guards around the md-speak calls in both Mode 1 (inline content) and Mode 2 (existing file path). Hardened sendAudio branch condition with `-n "${AUDIOPATH:-}"` guard for `set -u` safety.

## Review

- Implementation by Codex (gpt-5.4 high reasoning) via `danger-full-access` sandbox
- Code review by Claude subagent (`feature-dev:code-reviewer`) — verdict: **CLEAN**
- Codex audit: `~/claudes-world/tmp/codex-share-doc-no-audio-20260414-180653.md`
- One pre-existing issue flagged on line 73 (python3 apostrophe injection risk in `${FILEPATH}` interpolation) — documented but out-of-scope for this diff

## Test plan

- [x] `bash -n hooks/share-doc` — syntax OK
- [x] `cat /tmp/test.md | bash hooks/share-doc --no-audio` — exit 0, no .mp3 produced, sendMessage branch reached
- [x] Flag-absent path verified structurally identical to pre-patch behavior
- [ ] Smoke test once merged (Liam will verify in live Telegram)

🤖 Generated with [Claude Code](https://claude.com/claude-code)