### PR TITLE
fix: use agent's own bot token for hook notifications

### DIFF
--- a/hooks/common.sh
+++ b/hooks/common.sh
@@ -7,8 +7,10 @@
 # If chat ID can't be resolved, sets HOOK_ERROR with a message that
 # should be output as additionalContext so the model can fix it.
 
-# Bot token
-BOTTOKEN=$(grep TELEGRAM_BOT_TOKEN /home/claude/.claude/channels/telegram/.env 2>/dev/null | cut -d= -f2)
+# Bot token — use agent's own token when TELEGRAM_STATE_DIR is set
+_TOKEN_ENV="${TELEGRAM_STATE_DIR:+$TELEGRAM_STATE_DIR/.env}"
+_TOKEN_ENV="${_TOKEN_ENV:-/home/claude/.claude/channels/telegram/.env}"
+BOTTOKEN=$(grep TELEGRAM_BOT_TOKEN "$_TOKEN_ENV" 2>/dev/null | cut -d= -f2)
 
 # Chat ID — project-scoped active chat first
 HOOK_CWD="${HOOK_CWD:-$(pwd)}"


### PR DESCRIPTION
## Summary
- Agent start/stop hooks in `common.sh` hardcoded the orchestrator's bot token path (`~/.claude/channels/telegram/.env`), causing all agents to send notifications as @claude_do_bot
- Now reads from `$TELEGRAM_STATE_DIR/.env` when set (each agent exports this), falls back to orchestrator path when unset
- 3-line change: uses bash `${VAR:+alt}` / `${VAR:-default}` parameter expansion

## Test plan
- [x] Verified gstack-dobot's token resolves correctly when `TELEGRAM_STATE_DIR` is set
- [x] Verified orchestrator token still resolves when `TELEGRAM_STATE_DIR` is unset
- [x] Both paths produce different, valid tokens

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)