### PR TITLE
feat: add location-sharing button to launcher keyboard

### DIFF
--- a/hooks/actions-hook
+++ b/hooks/actions-hook
@@ -121,6 +121,40 @@ JSON
     send_msg "Done." "" "$LAUNCHER"
     echo '{"suppressOutput":true}'
     ;;
+  *latitude*longitude*|*longitude*latitude*)
+    mkdir -p ~/.claude/state/
+
+    # Try parsing as JSON first; fall back to grep/sed text extraction.
+    LAT=$(echo "$CONTENT" | jq -r '.latitude // empty' 2>/dev/null || true)
+    LON=$(echo "$CONTENT" | jq -r '.longitude // empty' 2>/dev/null || true)
+    if [ -z "$LAT" ] || [ -z "$LON" ]; then
+      LAT=$(echo "$CONTENT" | grep -oE '"latitude"[[:space:]]*:[[:space:]]*-?[0-9]+(\.[0-9]+)?' | sed -E 's/.*:[[:space:]]*//' | head -n1)
+      LON=$(echo "$CONTENT" | grep -oE '"longitude"[[:space:]]*:[[:space:]]*-?[0-9]+(\.[0-9]+)?' | sed -E 's/.*:[[:space:]]*//' | head -n1)
+    fi
+    if [ -z "$LAT" ] || [ -z "$LON" ]; then
+      send_msg "📍 Could not parse location coordinates." "" "$LAUNCHER"
+      echo '{"suppressOutput":true}'
+      exit 0
+    fi
+
+    CITY=$(curl -s "https://nominatim.openstreetmap.org/reverse?lat=${LAT}&lon=${LON}&format=json" \
+      | jq -r '.address.city // .address.town // .address.village // "Unknown"' 2>/dev/null || echo "Unknown")
+    [ -z "$CITY" ] && CITY="Unknown"
+
+    UPDATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    jq -n \
+      --argjson lat "$LAT" \
+      --argjson lon "$LON" \
+      --arg city "$CITY" \
+      --arg updated_at "$UPDATED_AT" \
+      '{latitude: $lat, longitude: $lon, city: $city, updated_at: $updated_at}' \
+      > ~/.claude/state/user-location.json
+
+    send_msg "📍 Location updated: ${CITY} (${LAT}, ${LON})"
+    send_msg "Done." "" "$LAUNCHER"
+    echo '{"suppressOutput":true}'
+    exit 0
+    ;;
   *)
     exit 0
     ;;

--- a/hooks/actions-hook
+++ b/hooks/actions-hook
@@ -122,7 +122,9 @@ JSON
     echo '{"suppressOutput":true}'
     ;;
   *latitude*longitude*|*longitude*latitude*)
-    mkdir -p ~/.claude/state/
+    # Per ADR 0014: runtime config lives in ~/claudes-world/.world/
+    LOCATION_FILE="$HOME/claudes-world/.world/user-location.json"
+    mkdir -p "$(dirname "$LOCATION_FILE")"
 
     # Try parsing as JSON first; fall back to grep/sed text extraction.
     LAT=$(echo "$CONTENT" | jq -r '.latitude // empty' 2>/dev/null || true)
@@ -142,13 +144,44 @@ JSON
     [ -z "$CITY" ] && CITY="Unknown"
 
     UPDATED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    jq -n \
+
+    # Build current + history schema per ADR 0014.
+    # If an existing current exists, archive it into history with
+    # arrived_at = old.updated_at and departed_at = new UPDATED_AT.
+    # History capped at 50 entries (drop oldest).
+    if [ -f "$LOCATION_FILE" ]; then
+      EXISTING=$(cat "$LOCATION_FILE" 2>/dev/null || echo '{}')
+    else
+      EXISTING='{}'
+    fi
+
+    NEW_JSON=$(jq -n \
+      --argjson existing "$EXISTING" \
       --argjson lat "$LAT" \
       --argjson lon "$LON" \
       --arg city "$CITY" \
       --arg updated_at "$UPDATED_AT" \
-      '{latitude: $lat, longitude: $lon, city: $city, updated_at: $updated_at}' \
-      > ~/.claude/state/user-location.json
+      '
+      ($existing.history // []) as $prior_history |
+      ($existing.current // null) as $prior_current |
+      (if $prior_current then
+         $prior_history + [{
+           latitude: $prior_current.latitude,
+           longitude: $prior_current.longitude,
+           city: $prior_current.city,
+           arrived_at: $prior_current.updated_at,
+           departed_at: $updated_at
+         }]
+       else
+         $prior_history
+       end) as $combined |
+      {
+        current: {latitude: $lat, longitude: $lon, city: $city, updated_at: $updated_at},
+        history: ($combined | (if length > 50 then .[length - 50:] else . end))
+      }
+      ')
+
+    echo "$NEW_JSON" > "$LOCATION_FILE"
 
     send_msg "📍 Location updated: ${CITY} (${LAT}, ${LON})"
     send_msg "Done." "" "$LAUNCHER"

--- a/hooks/lib/launcher-keyboard.sh
+++ b/hooks/lib/launcher-keyboard.sh
@@ -26,12 +26,17 @@ build_launcher_reply_markup() {
   cpc_auth_token=$(build_cpc_auth_token "$chat_id" "$bot_token")
 
   jq -cn --arg token "$cpc_auth_token" '{
-    keyboard: [[
-      {text: "⚡️\nActions"},
-      {text: "📱\nDevelop", web_app: {url: ("https://cpc.claude.do/dev/?token=" + $token)}},
-      {text: "🎙️\nVoice", web_app: {url: ("https://cpc.claude.do/#voice&token=" + $token)}},
-      {text: "📝\nScrum"}
-    ]],
+    keyboard: [
+      [
+        {text: "⚡️\nActions"},
+        {text: "📱\nDevelop", web_app: {url: ("https://cpc.claude.do/dev/?token=" + $token)}},
+        {text: "🎙️\nVoice", web_app: {url: ("https://cpc.claude.do/#voice&token=" + $token)}},
+        {text: "📝\nScrum"}
+      ],
+      [
+        {text: "📍\nLocation", request_location: true}
+      ]
+    ],
     resize_keyboard: true,
     is_persistent: true
   }'

--- a/morning-brief/morning-brief
+++ b/morning-brief/morning-brief
@@ -1,0 +1,334 @@
+#!/bin/bash
+# morning-brief — gather system health, PR staleness, weather, and dependency
+# alerts in parallel and output structured JSON or human-readable text.
+#
+# Usage:
+#     morning-brief          # human-readable summary
+#     morning-brief --json   # JSON object to stdout
+#
+# Environment variables:
+#     STALE_HOURS          PR staleness threshold in hours (default: 48)
+#     DISK_ALERT_PCT       Disk usage alert threshold percent (default: 80)
+#     MORNING_BRIEF_REPOS  Space-separated list of org/repo to check
+#                          (default: claudes-world/dobot-server claudes-world/inbox
+#                           claudes-world/claude-pocket-console claudes-world/toolbox)
+
+set -euo pipefail
+
+# ── configuration ─────────────────────────────────────────────────────────────
+
+STALE_HOURS="${STALE_HOURS:-48}"
+DISK_ALERT_PCT="${DISK_ALERT_PCT:-80}"
+DEFAULT_REPOS="claudes-world/dobot-server claudes-world/inbox claudes-world/claude-pocket-console claudes-world/toolbox"
+MORNING_BRIEF_REPOS="${MORNING_BRIEF_REPOS:-$DEFAULT_REPOS}"
+MODULE_TIMEOUT=5
+OUTPUT_JSON=false
+
+if [[ "${1:-}" == "--json" ]]; then
+  OUTPUT_JSON=true
+fi
+
+# ── temp dir for module outputs ───────────────────────────────────────────────
+
+TMPDIR_BRIEF=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BRIEF"' EXIT
+
+# ── module 1: weather ────────────────────────────────────────────────────────
+
+fetch_weather() {
+  local out="$TMPDIR_BRIEF/weather"
+  local err="$TMPDIR_BRIEF/weather_err"
+  local location="NewYork"
+  local loc_file="$HOME/.claude/state/user-location.json"
+  if [[ -f "$loc_file" ]]; then
+    local saved_city
+    saved_city=$(jq -r '.city // empty' "$loc_file" 2>/dev/null || true)
+    if [[ -n "$saved_city" ]]; then
+      location="$saved_city"
+    fi
+  fi
+  # write location name so the output header can read it back
+  printf '%s' "$location" > "$TMPDIR_BRIEF/weather_location"
+  if timeout "$MODULE_TIMEOUT" curl -sf "wttr.in/${location}?format=%c+%t+%h+%w" > "$out" 2>"$err"; then
+    :
+  else
+    echo "(unavailable)" > "$out"
+    echo "weather: curl failed or timed out" > "$err"
+  fi
+}
+
+# ── module 2: PR staleness ───────────────────────────────────────────────────
+
+fetch_pr_staleness() {
+  local out="$TMPDIR_BRIEF/pr_staleness"
+  local err="$TMPDIR_BRIEF/pr_staleness_err"
+  local pids=()
+  local repo_dir="$TMPDIR_BRIEF/repos"
+  mkdir -p "$repo_dir"
+
+  if ! command -v gh &>/dev/null; then
+    echo "[]" > "$out"
+    echo "pr_staleness: gh CLI not found" > "$err"
+    return
+  fi
+
+  local now_epoch
+  now_epoch=$(date +%s)
+  local stale_seconds=$(( STALE_HOURS * 3600 ))
+
+  # Fetch PRs from each repo in parallel
+  for repo in $MORNING_BRIEF_REPOS; do
+    local safe_name
+    safe_name=$(echo "$repo" | tr '/' '_')
+    (
+      if timeout "$MODULE_TIMEOUT" gh pr list --repo "$repo" \
+        --json number,title,updatedAt --limit 50 > "$repo_dir/$safe_name" 2>/dev/null; then
+        :
+      else
+        echo "[]" > "$repo_dir/$safe_name"
+      fi
+    ) &
+    pids+=($!)
+  done
+
+  # Wait for all repo fetches
+  for pid in "${pids[@]}"; do
+    wait "$pid" 2>/dev/null || true
+  done
+
+  # Assemble stale PRs
+  local stale_prs="[]"
+  for repo in $MORNING_BRIEF_REPOS; do
+    local safe_name
+    safe_name=$(echo "$repo" | tr '/' '_')
+    local file="$repo_dir/$safe_name"
+    [[ -f "$file" ]] || continue
+
+    # Filter for stale PRs using jq
+    local repo_stale
+    repo_stale=$(jq -r --arg repo "$repo" --argjson now "$now_epoch" --argjson threshold "$stale_seconds" '
+      [.[] | select(
+        (($now - ((.updatedAt | sub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime))) > $threshold)
+      ) | {repo: $repo, number, title, updatedAt,
+            stale_hours: ((($now - ((.updatedAt | sub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime))) / 3600) | floor)}]
+    ' "$file" 2>/dev/null || echo "[]")
+
+    stale_prs=$(jq -s '.[0] + .[1]' <(echo "$stale_prs") <(echo "$repo_stale") 2>/dev/null || echo "$stale_prs")
+  done
+
+  echo "$stale_prs" > "$out"
+  echo "" > "$err"
+}
+
+# ── module 3: disk + service health ──────────────────────────────────────────
+
+fetch_health() {
+  local out="$TMPDIR_BRIEF/health"
+  local err="$TMPDIR_BRIEF/health_err"
+  local health="{}"
+
+  # Disk usage
+  local disk_pct
+  disk_pct=$(df -h / | awk 'NR==2 {gsub(/%/,""); print $5}' 2>/dev/null || echo "0")
+  local disk_total disk_used disk_avail
+  read -r disk_total disk_used disk_avail <<< "$(df -h / | awk 'NR==2 {print $2, $3, $4}' 2>/dev/null || echo "? ? ?")"
+  local disk_alert=false
+  if (( disk_pct > DISK_ALERT_PCT )); then
+    disk_alert=true
+  fi
+
+  # Service checks
+  local cpc_status cloudflared_status
+  cpc_status=$(systemctl --user is-active cpc.service 2>/dev/null || echo "unknown")
+  cloudflared_status=$(systemctl is-active cloudflared 2>/dev/null || echo "unknown")
+
+  # tmux sessions
+  local tmux_sessions
+  tmux_sessions=$(tmux list-sessions -F '#{session_name}' 2>/dev/null | jq -R -s 'split("\n") | map(select(. != ""))' 2>/dev/null || echo "[]")
+
+  health=$(jq -n \
+    --argjson disk_pct "$disk_pct" \
+    --arg disk_total "$disk_total" \
+    --arg disk_used "$disk_used" \
+    --arg disk_avail "$disk_avail" \
+    --argjson disk_alert "$disk_alert" \
+    --arg cpc "$cpc_status" \
+    --arg cloudflared "$cloudflared_status" \
+    --argjson tmux "$tmux_sessions" \
+    '{
+      disk: {percent: $disk_pct, total: $disk_total, used: $disk_used, available: $disk_avail, alert: $disk_alert},
+      services: {cpc: $cpc, cloudflared: $cloudflared},
+      tmux_sessions: $tmux
+    }')
+
+  echo "$health" > "$out"
+  echo "" > "$err"
+}
+
+# ── module 4: dependency alerts ──────────────────────────────────────────────
+
+fetch_dep_alerts() {
+  local out="$TMPDIR_BRIEF/dep_alerts"
+  local err="$TMPDIR_BRIEF/dep_alerts_err"
+  local repo_dirs=(
+    "$HOME/code/claude-pocket-console"
+    "$HOME/code/toolbox"
+    "$HOME/code/tryinbox-sh"
+    "$HOME/code/dobot-server"
+  )
+  local alerts="{}"
+  local pids=()
+  local dep_dir="$TMPDIR_BRIEF/deps"
+  mkdir -p "$dep_dir"
+
+  for dir in "${repo_dirs[@]}"; do
+    [[ -f "$dir/package.json" ]] || continue
+    local basename
+    basename=$(basename "$dir")
+    (
+      local outdated=""
+      if cd "$dir" 2>/dev/null; then
+        # pnpm outdated exits 1 when outdated deps exist but still outputs valid JSON
+        outdated=$(timeout "$MODULE_TIMEOUT" pnpm outdated --format json 2>/dev/null) || true
+        # If pnpm didn't produce valid JSON, try npm
+        if ! echo "$outdated" | jq empty 2>/dev/null; then
+          outdated=$(timeout "$MODULE_TIMEOUT" npm outdated --json 2>/dev/null) || true
+        fi
+      fi
+      # Ensure we always write valid JSON
+      if ! echo "$outdated" | jq empty 2>/dev/null; then
+        outdated="{}"
+      fi
+      echo "$outdated" > "$dep_dir/$basename"
+    ) &
+    pids+=($!)
+  done
+
+  for pid in "${pids[@]}"; do
+    wait "$pid" 2>/dev/null || true
+  done
+
+  # Summarize counts per repo
+  for dir in "${repo_dirs[@]}"; do
+    [[ -f "$dir/package.json" ]] || continue
+    local basename
+    basename=$(basename "$dir")
+    local file="$dep_dir/$basename"
+    [[ -f "$file" ]] || continue
+
+    local count
+    count=$(jq 'length // 0' "$file" 2>/dev/null || echo 0)
+    # Guard against empty count (e.g. empty file)
+    [[ -z "$count" || "$count" == "null" ]] && count=0
+    alerts=$(echo "$alerts" | jq --arg repo "$basename" --argjson count "$count" '. + {($repo): $count}')
+  done
+
+  echo "$alerts" > "$out"
+  echo "" > "$err"
+}
+
+# ── run all modules in parallel ──────────────────────────────────────────────
+
+fetch_weather &
+PID_WEATHER=$!
+
+fetch_pr_staleness &
+PID_PR=$!
+
+fetch_health &
+PID_HEALTH=$!
+
+fetch_dep_alerts &
+PID_DEPS=$!
+
+wait "$PID_WEATHER" 2>/dev/null || true
+wait "$PID_PR" 2>/dev/null || true
+wait "$PID_HEALTH" 2>/dev/null || true
+wait "$PID_DEPS" 2>/dev/null || true
+
+# ── collect results ──────────────────────────────────────────────────────────
+
+WEATHER=$(cat "$TMPDIR_BRIEF/weather" 2>/dev/null || echo "(unavailable)")
+PR_STALENESS=$(cat "$TMPDIR_BRIEF/pr_staleness" 2>/dev/null || echo "[]")
+HEALTH=$(cat "$TMPDIR_BRIEF/health" 2>/dev/null || echo "{}")
+DEP_ALERTS=$(cat "$TMPDIR_BRIEF/dep_alerts" 2>/dev/null || echo "{}")
+
+# Collect errors
+ERRORS="[]"
+for mod in weather pr_staleness health dep_alerts; do
+  err_file="$TMPDIR_BRIEF/${mod}_err"
+  if [[ -f "$err_file" ]]; then
+    err_content=$(cat "$err_file" | tr -d '\n')
+    if [[ -n "$err_content" ]]; then
+      ERRORS=$(echo "$ERRORS" | jq --arg e "$err_content" '. + [$e]')
+    fi
+  fi
+done
+
+# ── output ────────────────────────────────────────────────────────────────────
+
+if $OUTPUT_JSON; then
+  jq -n \
+    --arg weather "$WEATHER" \
+    --argjson pr_staleness "$PR_STALENESS" \
+    --argjson health "$HEALTH" \
+    --argjson dep_alerts "$DEP_ALERTS" \
+    --argjson errors "$ERRORS" \
+    '{weather: $weather, pr_staleness: $pr_staleness, health: $health, dep_alerts: $dep_alerts, errors: $errors}'
+else
+  # Human-readable output
+  echo "=== Morning Brief ==="
+  echo ""
+
+  # Weather
+  WEATHER_LOC=$(cat "$TMPDIR_BRIEF/weather_location" 2>/dev/null || echo "New York")
+  [ -z "$WEATHER_LOC" ] && WEATHER_LOC="New York"
+  echo "## Weather (${WEATHER_LOC})"
+  echo "  $WEATHER"
+  echo ""
+
+  # PR Staleness
+  echo "## Stale PRs (>${STALE_HOURS}h since update)"
+  stale_count=$(echo "$PR_STALENESS" | jq 'length' 2>/dev/null || echo 0)
+  if (( stale_count == 0 )); then
+    echo "  No stale PRs"
+  else
+    echo "$PR_STALENESS" | jq -r '.[] | "  #\(.number) \(.repo) — \(.title) (\(.stale_hours)h stale)"' 2>/dev/null
+  fi
+  echo ""
+
+  # Health
+  echo "## System Health"
+  disk_pct=$(echo "$HEALTH" | jq -r '.disk.percent // "?"' 2>/dev/null)
+  disk_alert=$(echo "$HEALTH" | jq -r '.disk.alert // false' 2>/dev/null)
+  disk_used=$(echo "$HEALTH" | jq -r '.disk.used // "?"' 2>/dev/null)
+  disk_total=$(echo "$HEALTH" | jq -r '.disk.total // "?"' 2>/dev/null)
+  echo "  Disk: ${disk_used}/${disk_total} (${disk_pct}%)$([ "$disk_alert" = "true" ] && echo " *** ALERT ***")"
+
+  cpc=$(echo "$HEALTH" | jq -r '.services.cpc // "unknown"' 2>/dev/null)
+  cf=$(echo "$HEALTH" | jq -r '.services.cloudflared // "unknown"' 2>/dev/null)
+  echo "  CPC service: $cpc"
+  echo "  Cloudflared: $cf"
+
+  tmux_list=$(echo "$HEALTH" | jq -r '.tmux_sessions // [] | join(", ")' 2>/dev/null)
+  echo "  tmux sessions: ${tmux_list:-(none)}"
+  echo ""
+
+  # Dependency Alerts
+  echo "## Dependency Alerts"
+  dep_count=$(echo "$DEP_ALERTS" | jq 'to_entries | map(select(.value > 0)) | length' 2>/dev/null || echo 0)
+  if (( dep_count == 0 )); then
+    echo "  All dependencies up to date"
+  else
+    echo "$DEP_ALERTS" | jq -r 'to_entries[] | select(.value > 0) | "  \(.key): \(.value) outdated"' 2>/dev/null
+  fi
+  echo ""
+
+  # Errors
+  err_count=$(echo "$ERRORS" | jq 'length' 2>/dev/null || echo 0)
+  if (( err_count > 0 )); then
+    echo "## Errors"
+    echo "$ERRORS" | jq -r '.[] | "  - \(.)"' 2>/dev/null
+    echo ""
+  fi
+fi

--- a/morning-brief/morning-brief
+++ b/morning-brief/morning-brief
@@ -39,10 +39,11 @@ fetch_weather() {
   local out="$TMPDIR_BRIEF/weather"
   local err="$TMPDIR_BRIEF/weather_err"
   local location="NewYork"
-  local loc_file="$HOME/.claude/state/user-location.json"
+  # Per ADR 0014: runtime config lives in ~/claudes-world/.world/
+  local loc_file="$HOME/claudes-world/.world/user-location.json"
   if [[ -f "$loc_file" ]]; then
     local saved_city
-    saved_city=$(jq -r '.city // empty' "$loc_file" 2>/dev/null || true)
+    saved_city=$(jq -r '.current.city // empty' "$loc_file" 2>/dev/null || true)
     if [[ -n "$saved_city" ]]; then
       location="$saved_city"
     fi


### PR DESCRIPTION
## Summary
- Add 📍 Location button (row 2, `request_location: true`) to the launcher keyboard so users can share GPS coordinates with a single tap
- Handle incoming location in `actions-hook`: parse lat/lon, reverse-geocode city via Nominatim, save to `~/.claude/state/user-location.json`
- Update `morning-brief` weather module to read saved location instead of hardcoded "NewYork" (falls back to NewYork if no location file)

## Test plan
- [ ] Verify keyboard JSON is valid (validated via `jq` in CI)
- [ ] Tap 📍 Location button in Telegram — confirm GPS prompt appears
- [ ] Share location — confirm `user-location.json` is written with correct lat/lon/city
- [ ] Confirm launcher keyboard restores after location share
- [ ] Run `morning-brief` with and without `user-location.json` — verify city in weather header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>