### PR TITLE
feat(md-speak): per-column voice for table cells — key/val female voice split

### DIFF
--- a/md-speak/md-speak
+++ b/md-speak/md-speak
@@ -7,11 +7,13 @@ Usage:
     md-speak --no-describe document.md    # skip AI descriptions of code/images
 
 Voice roles (Google Cloud TTS, overridable via env):
-    MD_VOICE_HEADING:  Headings (default: en-US-Wavenet-B, deep male)
-    MD_VOICE_BODY:     Body text (default: en-US-Wavenet-J, male)
-    MD_VOICE_SPECIAL:  Links, figures, code descriptions (default: en-US-Neural2-C, female)
-    MD_VOICE_TABLE:    Table content (default: en-US-Neural2-A, male)
-    MD_VOICE_QUOTE:    Blockquotes (default: en-US-Wavenet-D, male)
+    MD_VOICE_HEADING:    Headings (default: en-US-Wavenet-B, deep male)
+    MD_VOICE_BODY:       Body text (default: en-US-Wavenet-J, male)
+    MD_VOICE_SPECIAL:    Links, figures, code descriptions (default: en-US-Neural2-C, female)
+    MD_VOICE_TABLE:      Table content (default: en-US-Neural2-F, female)
+    MD_VOICE_TABLE_KEY:  Table col 0 / headers (default: en-US-Neural2-H, female — row labels)
+    MD_VOICE_TABLE_VAL:  Table col 1+ (default: en-US-Neural2-F, female — values)
+    MD_VOICE_QUOTE:      Blockquotes (default: en-US-Wavenet-D, male)
 
 Requires:
     - GCP service account at ~/.secrets/gcp-tts-sa.json
@@ -38,6 +40,8 @@ VOICES = {
     "special": os.environ.get("MD_VOICE_SPECIAL", "en-US-Neural2-C"),
     "table": os.environ.get("MD_VOICE_TABLE", "en-US-Neural2-F"),
     "table_header": os.environ.get("MD_VOICE_TABLE_HEADER", "en-US-Neural2-C"),
+    "table_key": os.environ.get("MD_VOICE_TABLE_KEY", "en-US-Neural2-H"),    # col 0 — row labels
+    "table_val": os.environ.get("MD_VOICE_TABLE_VAL", "en-US-Neural2-F"),    # col 1+ — values
     "quote": os.environ.get("MD_VOICE_QUOTE", "en-US-Wavenet-D"),
 }
 
@@ -356,33 +360,48 @@ def process_markdown(md_text: str, use_ai: bool = True) -> list[Segment]:
                     pass  # fall back to heuristic
 
             if use_repeat_headers:
-                # Mode B: repeat headers with every cell
+                # Mode B: repeat header inline before each value, voiced per column
                 for row in all_rows:
-                    pairs = []
                     for j, val in enumerate(row):
+                        voice = VOICES["table_key"] if j == 0 else VOICES["table_val"]
                         if j < len(header_texts):
-                            pairs.append(f"{header_texts[j]}, {val}")
+                            text = f"{header_texts[j]}, {val}"
                         else:
-                            pairs.append(val)
-                    segments.append(Segment(
-                        text=". ".join(pairs),
-                        voice=VOICES["table"],
-                        pause_after=PAUSE["between_table_rows"],
-                    ))
+                            text = val
+                        if text:
+                            segments.append(Segment(
+                                text=text,
+                                voice=voice,
+                                pause_after=PAUSE["between_table_cells"],
+                            ))
+                    # Extra pause after each row
+                    if segments and segments[-1].pause_after < PAUSE["between_table_rows"]:
+                        segments[-1].pause_after = PAUSE["between_table_rows"]
             else:
-                # Mode A: headers once, then rows
+                # Mode A: headers once (all with table_key voice), then rows cell-by-cell
+                for j, h in enumerate(header_texts):
+                    if h:
+                        segments.append(Segment(
+                            text=h,
+                            voice=VOICES["table_key"],
+                            pause_after=PAUSE["between_table_cells"],
+                        ))
                 if header_texts:
-                    segments.append(Segment(
-                        text=", ".join(header_texts),
-                        voice=VOICES["table_header"],
-                        pause_after=PAUSE["between_table_rows"],
-                    ))
+                    # Upgrade pause after last header to row-level
+                    if segments and segments[-1].pause_after < PAUSE["between_table_rows"]:
+                        segments[-1].pause_after = PAUSE["between_table_rows"]
                 for row in all_rows:
-                    segments.append(Segment(
-                        text=", ".join(row),
-                        voice=VOICES["table"],
-                        pause_after=PAUSE["between_table_rows"],
-                    ))
+                    for j, val in enumerate(row):
+                        voice = VOICES["table_key"] if j == 0 else VOICES["table_val"]
+                        if val:
+                            segments.append(Segment(
+                                text=val,
+                                voice=voice,
+                                pause_after=PAUSE["between_table_cells"],
+                            ))
+                    # Upgrade pause after last cell in row
+                    if segments and segments[-1].pause_after < PAUSE["between_table_rows"]:
+                        segments[-1].pause_after = PAUSE["between_table_rows"]
 
             segments.append(Segment(text="", voice=VOICES["body"], pause_before=PAUSE["after_table"]))
 

--- a/md-speak/md-speak
+++ b/md-speak/md-speak
@@ -37,7 +37,6 @@ VOICES = {
     "heading": os.environ.get("MD_VOICE_HEADING", "en-US-Wavenet-B"),
     "body": os.environ.get("MD_VOICE_BODY", "en-US-Wavenet-J"),
     "special": os.environ.get("MD_VOICE_SPECIAL", "en-US-Neural2-C"),
-    "table": os.environ.get("MD_VOICE_TABLE", "en-US-Neural2-F"),
     "table_key": os.environ.get("MD_VOICE_TABLE_KEY", "en-US-Neural2-H"),    # col 0 — row labels
     "table_val": os.environ.get("MD_VOICE_TABLE_VAL", "en-US-Neural2-F"),    # col 1+ — values
     "quote": os.environ.get("MD_VOICE_QUOTE", "en-US-Wavenet-D"),

--- a/md-speak/md-speak
+++ b/md-speak/md-speak
@@ -364,7 +364,7 @@ def process_markdown(md_text: str, use_ai: bool = True) -> list[Segment]:
                         if not val:
                             continue
                         voice = VOICES["table_key"] if j == 0 else VOICES["table_val"]
-                        text = f"{header_texts[j]}, {val}" if j < len(header_texts) else val
+                        text = f"{header_texts[j]}, {val}" if j < len(header_texts) and header_texts[j] else val
                         segments.append(Segment(
                             text=text,
                             voice=voice,

--- a/md-speak/md-speak
+++ b/md-speak/md-speak
@@ -10,7 +10,6 @@ Voice roles (Google Cloud TTS, overridable via env):
     MD_VOICE_HEADING:    Headings (default: en-US-Wavenet-B, deep male)
     MD_VOICE_BODY:       Body text (default: en-US-Wavenet-J, male)
     MD_VOICE_SPECIAL:    Links, figures, code descriptions (default: en-US-Neural2-C, female)
-    MD_VOICE_TABLE:      Table content (default: en-US-Neural2-F, female)
     MD_VOICE_TABLE_KEY:  Table col 0 / headers (default: en-US-Neural2-H, female — row labels)
     MD_VOICE_TABLE_VAL:  Table col 1+ (default: en-US-Neural2-F, female — values)
     MD_VOICE_QUOTE:      Blockquotes (default: en-US-Wavenet-D, male)
@@ -39,7 +38,6 @@ VOICES = {
     "body": os.environ.get("MD_VOICE_BODY", "en-US-Wavenet-J"),
     "special": os.environ.get("MD_VOICE_SPECIAL", "en-US-Neural2-C"),
     "table": os.environ.get("MD_VOICE_TABLE", "en-US-Neural2-F"),
-    "table_header": os.environ.get("MD_VOICE_TABLE_HEADER", "en-US-Neural2-C"),
     "table_key": os.environ.get("MD_VOICE_TABLE_KEY", "en-US-Neural2-H"),    # col 0 — row labels
     "table_val": os.environ.get("MD_VOICE_TABLE_VAL", "en-US-Neural2-F"),    # col 1+ — values
     "quote": os.environ.get("MD_VOICE_QUOTE", "en-US-Wavenet-D"),
@@ -363,17 +361,15 @@ def process_markdown(md_text: str, use_ai: bool = True) -> list[Segment]:
                 # Mode B: repeat header inline before each value, voiced per column
                 for row in all_rows:
                     for j, val in enumerate(row):
+                        if not val:
+                            continue
                         voice = VOICES["table_key"] if j == 0 else VOICES["table_val"]
-                        if j < len(header_texts):
-                            text = f"{header_texts[j]}, {val}"
-                        else:
-                            text = val
-                        if text:
-                            segments.append(Segment(
-                                text=text,
-                                voice=voice,
-                                pause_after=PAUSE["between_table_cells"],
-                            ))
+                        text = f"{header_texts[j]}, {val}" if j < len(header_texts) else val
+                        segments.append(Segment(
+                            text=text,
+                            voice=voice,
+                            pause_after=PAUSE["between_table_cells"],
+                        ))
                     # Extra pause after each row
                     if segments and segments[-1].pause_after < PAUSE["between_table_rows"]:
                         segments[-1].pause_after = PAUSE["between_table_rows"]

--- a/md-speak/md-speak
+++ b/md-speak/md-speak
@@ -360,6 +360,7 @@ def process_markdown(md_text: str, use_ai: bool = True) -> list[Segment]:
             if use_repeat_headers:
                 # Mode B: repeat header inline before each value, voiced per column
                 for row in all_rows:
+                    row_start_len = len(segments)
                     for j, val in enumerate(row):
                         if not val:
                             continue
@@ -370,11 +371,12 @@ def process_markdown(md_text: str, use_ai: bool = True) -> list[Segment]:
                             voice=voice,
                             pause_after=PAUSE["between_table_cells"],
                         ))
-                    # Extra pause after each row
-                    if segments and segments[-1].pause_after < PAUSE["between_table_rows"]:
+                    # Upgrade pause after last cell in row (only if any cells were emitted)
+                    if len(segments) > row_start_len and segments[-1].pause_after < PAUSE["between_table_rows"]:
                         segments[-1].pause_after = PAUSE["between_table_rows"]
             else:
                 # Mode A: headers once (all with table_key voice), then rows cell-by-cell
+                header_start_len = len(segments)
                 for j, h in enumerate(header_texts):
                     if h:
                         segments.append(Segment(
@@ -382,11 +384,12 @@ def process_markdown(md_text: str, use_ai: bool = True) -> list[Segment]:
                             voice=VOICES["table_key"],
                             pause_after=PAUSE["between_table_cells"],
                         ))
-                if header_texts:
+                if len(segments) > header_start_len:
                     # Upgrade pause after last header to row-level
-                    if segments and segments[-1].pause_after < PAUSE["between_table_rows"]:
+                    if segments[-1].pause_after < PAUSE["between_table_rows"]:
                         segments[-1].pause_after = PAUSE["between_table_rows"]
                 for row in all_rows:
+                    row_start_len = len(segments)
                     for j, val in enumerate(row):
                         voice = VOICES["table_key"] if j == 0 else VOICES["table_val"]
                         if val:
@@ -395,8 +398,8 @@ def process_markdown(md_text: str, use_ai: bool = True) -> list[Segment]:
                                 voice=voice,
                                 pause_after=PAUSE["between_table_cells"],
                             ))
-                    # Upgrade pause after last cell in row
-                    if segments and segments[-1].pause_after < PAUSE["between_table_rows"]:
+                    # Upgrade pause after last cell in row (only if any cells were emitted)
+                    if len(segments) > row_start_len and segments[-1].pause_after < PAUSE["between_table_rows"]:
                         segments[-1].pause_after = PAUSE["between_table_rows"]
 
             segments.append(Segment(text="", voice=VOICES["body"], pause_before=PAUSE["after_table"]))


### PR DESCRIPTION
## Summary

- Table cells now emit one TTS `Segment` per cell (was: one per row)
- Col 0 / headers → `table_key` voice (`en-US-Neural2-H`, warm female — row labels)
- Col 1+ → `table_val` voice (`en-US-Neural2-F`, brighter female — values)
- Both voices env-overridable via `MD_VOICE_TABLE_KEY` / `MD_VOICE_TABLE_VAL`
- AI-selected Mode A (narrow) and Mode B (wide/comparison) both updated for per-cell dispatch
- Empty cells correctly skipped in both modes (no dangling-comma TTS calls)
- Pause sequencing: `between_table_cells` (0.2s) between cells, `between_table_rows` (0.5s) at row end

## Changes

Single file: `md-speak/md-speak`
- `VOICES` dict: add `table_key`, `table_val`; remove dead `table_header` entry
- Table AST handler: replace row-string assembly with per-cell `Segment` emission
- Docstring: update env var list to reflect live keys only

## Test plan

- [ ] Run md-speak on a 2-col key-value table → Mode A: headers once (Neural2-H), then col 0 cells (H), col 1 cells (F)
- [ ] Run md-speak on a 4-col comparison table → Mode B: each cell prefixed with header, col 0 (H), col 1+ (F)
- [ ] Table with empty cells → no "label, " TTS artifact
- [ ] Non-table content unchanged

## Review

Local 3-tier swarm (Claude + Codex + Gemini): **2 rounds, CLEAN**. Round 1 found Mode B empty-cell bug; fixed before round 2.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)