### PR TITLE
docs(pulse): SKILL + SOP + ADR 0015 + READMEs (#45)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Hooks are event-driven scripts in `hooks/` wired via `.claude/settings.json`.
 2. Source `hooks/common.sh` if the hook needs to resolve a Telegram chat ID
 3. Make it executable: `chmod +x hooks/<hook-name>`
 4. Add a row to the hook registry table in `hooks/README.md` (name, event, purpose, status)
-5. Wire in `.claude/settings.json` or project `settings.local.json` under the appropriate event key
+5. Wire in `.claude/settings.json` or project `.claude/settings.local.json` under the appropriate event key
 6. Test with a real Claude Code session; verify output JSON shape matches the hook schema
 
 ### Tool Design Principles

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,6 @@ Hooks are event-driven scripts in `hooks/` wired via `.claude/settings.json`.
 | ADR | Topic | Relevance |
 |-----|-------|-----------|
 | [ADR 0003](~/claudes-world/knowledge/adr/0003-port-allocation-v2-port-for.md) | Port allocation | Use `port-for` before binding any port; project-sharded 38xxx/58xxx bands |
-| [ADR 0006](~/claudes-world/knowledge/adr/0006-world-bootstrap.md) | `.world/` bootstrap and precedence | Per-project `.world/` overlay pattern; where runtime state lives |
+| [ADR 0006](~/claudes-world/knowledge/adr/0006-world-directory-bootstrap-and-precedence.md) | `.world/` bootstrap and precedence | Per-project `.world/` overlay pattern; where runtime state lives |
 | [ADR 0014](~/claudes-world/knowledge/adr/0014-world-runtime-config.md) | `.world/` runtime config | `~/.world/pulse/` follows this convention for token, config, DB, snapshots |
 | [ADR 0015](~/claudes-world/knowledge/adr/0015-org-pulse.md) | Org-pulse design | Decision record for the `pulse` package: GraphQL, SQLite, systemd timer, future extensibility |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ For tools that ship as a proper Python package (entry point in `pyproject.toml`)
 
 1. Create `<tool-name>/` directory with `__init__.py` and supporting modules
 2. Add an entry point in `pyproject.toml` under `[project.scripts]`: `tool-name = "tool_name.__main__:main"`
-3. Install into the shared venv: `pip install -e ~/code/toolbox/`
+3. Install into the shared venv: `~/venvs/transcribe/bin/pip install -e ~/code/toolbox/`
 4. Add a `<tool-name>/README.md` documenting: overview, installation, configuration, CLI subcommands, storage, and troubleshooting
 5. Update the root `README.md` with the new tool entry and a link to the package README
 6. Update `AGENTS.md` with any ADR cross-references for architectural decisions the tool introduces

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,28 @@ Never commit secrets. Tools should read credentials from:
 - `~/.secrets/gcp-tts-sa.json` — Google Cloud service account
 - Environment variables as fallback
 
+### Adding a Python package tool
+
+For tools that ship as a proper Python package (entry point in `pyproject.toml`) rather than a standalone script:
+
+1. Create `<tool-name>/` directory with `__init__.py` and supporting modules
+2. Add an entry point in `pyproject.toml` under `[project.scripts]`: `tool-name = "tool_name.__main__:main"`
+3. Install into the shared venv: `pip install -e ~/code/toolbox/`
+4. Add a `<tool-name>/README.md` documenting: overview, installation, configuration, CLI subcommands, storage, and troubleshooting
+5. Update the root `README.md` with the new tool entry and a link to the package README
+6. Update `AGENTS.md` with any ADR cross-references for architectural decisions the tool introduces
+
+### Adding a hook
+
+Hooks are event-driven scripts in `hooks/` wired via `.claude/settings.json`.
+
+1. Create `hooks/<hook-name>` with a shebang and `set -euo pipefail`
+2. Source `hooks/common.sh` if the hook needs to resolve a Telegram chat ID
+3. Make it executable: `chmod +x hooks/<hook-name>`
+4. Add a row to the hook registry table in `hooks/README.md` (name, event, purpose, status)
+5. Wire in `.claude/settings.json` or project `settings.local.json` under the appropriate event key
+6. Test with a real Claude Code session; verify output JSON shape matches the hook schema
+
 ### Tool Design Principles
 
 - Each tool should be self-contained and runnable from `~/bin/` via symlink
@@ -41,3 +63,12 @@ Never commit secrets. Tools should read credentials from:
 - Default to the cheapest provider/model that produces acceptable quality
 - Output to stdout by default, `--out` flag for file output
 - Print status/progress to stderr, results to stdout
+
+## ADR cross-references
+
+| ADR | Topic | Relevance |
+|-----|-------|-----------|
+| [ADR 0003](~/claudes-world/knowledge/adr/0003-port-allocation-v2-port-for.md) | Port allocation | Use `port-for` before binding any port; project-sharded 38xxx/58xxx bands |
+| [ADR 0006](~/claudes-world/knowledge/adr/0006-world-bootstrap.md) | `.world/` bootstrap and precedence | Per-project `.world/` overlay pattern; where runtime state lives |
+| [ADR 0014](~/claudes-world/knowledge/adr/0014-world-runtime-config.md) | `.world/` runtime config | `~/.world/pulse/` follows this convention for token, config, DB, snapshots |
+| [ADR 0015](~/claudes-world/knowledge/adr/0015-org-pulse.md) | Org-pulse design | Decision record for the `pulse` package: GraphQL, SQLite, systemd timer, future extensibility |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All tools use a shared Python venv at `~/venvs/transcribe/` and are symlinked in
 | [speak](#speak) | Text-to-speech with OpenAI, Google, or ElevenLabs |
 | [md-speak](#md-speak) | Read markdown documents aloud with multiple voices |
 | [voice-hook](#voice-hook) | Claude Code hook: auto-transcribe Telegram voice notes |
-| [pulse](#pulse) | GitHub org activity snapshots — open PRs, issues, releases, Dependabot |
+| [pulse](pulse/README.md) | GitHub org activity snapshots — open PRs, issues, releases, Dependabot |
 
 ---
 
@@ -177,9 +177,24 @@ python3 -m venv ~/venvs/transcribe
 ~/venvs/transcribe/bin/pip install openai elevenlabs google-cloud-texttospeech mistune anthropic
 ```
 
+## Additional tools
+
+Standalone tools that don't have their own README section yet.
+
+| Tool | Description | Docs |
+|------|-------------|------|
+| gen-image | Generate images via Google Gemini/Imagen API | `gen-image/` |
+| morning-brief | Gather system health, PR staleness, weather, and dependency alerts in parallel; output JSON or human-readable text | `morning-brief/` |
+| openai-usage | Query OpenAI costs and usage; optionally send summary to Telegram | `openai-usage/` |
+| ports | Dynamic port map of all listening TCP services on the VPS (port, process, PID, tunnel hostname, systemd status) | `ports/` |
+| tag-mp3 | Tag an mp3 file with ID3 metadata and optional album art | `tag-mp3/` |
+| tg-sanitize | Telegram MarkdownV2 sanitizer — escapes special characters for safe bot messages | `tg-sanitize/` |
+
 ## Hooks
 
-Claude Code hooks that run automatically during sessions. These live in `hooks/` and are wired up via `.claude/settings.local.json`.
+Claude Code hooks that run automatically during sessions. Full hook registry and wiring guide: [`hooks/README.md`](hooks/README.md).
+
+These live in `hooks/` and are wired up via `.claude/settings.local.json`.
 
 ### voice-hook
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Full documentation: [`pulse/README.md`](pulse/README.md)
 pip install -e ~/code/toolbox/
 mkdir -p ~/.world/pulse && chmod 700 ~/.world/pulse
 echo "GH_TOKEN=ghp_yourtoken" > ~/.world/pulse/env && chmod 600 ~/.world/pulse/env
+cp ~/code/toolbox/systemd/user/config.yml ~/.world/pulse/config.yml
+# edit ~/.world/pulse/config.yml — set your org name under `orgs:`
 export $(grep -v '^#' ~/.world/pulse/env | xargs)
 pulse --self-check    # validate token, config, storage
 pulse --now           # run snapshot + render digest

--- a/README.md
+++ b/README.md
@@ -124,11 +124,13 @@ GitHub org activity monitor. Periodic GraphQL snapshots — open PRs, issues, De
 Full documentation: [`pulse/README.md`](pulse/README.md)
 
 **Quick start:**
-```
+```bash
 pip install -e ~/code/toolbox/
-export $(grep -v '^#' ~/.world/pulse/env | xargs)   # load and export token
-pulse --now                  # run snapshot + render digest
-pulse --self-check           # validate token, config, storage
+mkdir -p ~/.world/pulse && chmod 700 ~/.world/pulse
+echo "GH_TOKEN=ghp_yourtoken" > ~/.world/pulse/env && chmod 600 ~/.world/pulse/env
+export $(grep -v '^#' ~/.world/pulse/env | xargs)
+pulse --self-check    # validate token, config, storage
+pulse --now           # run snapshot + render digest
 ```
 
 **Files:**

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Full documentation: [`pulse/README.md`](pulse/README.md)
 **Quick start:**
 ```bash
 ~/venvs/transcribe/bin/pip install -e ~/code/toolbox/
+ln -sf ~/code/toolbox/bin/pulse ~/bin/pulse   # add to PATH
 mkdir -p ~/.world/pulse && chmod 700 ~/.world/pulse
 echo "GH_TOKEN=ghp_yourtoken" > ~/.world/pulse/env && chmod 600 ~/.world/pulse/env
 cp ~/code/toolbox/systemd/user/config.yml ~/.world/pulse/config.yml

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Full documentation: [`pulse/README.md`](pulse/README.md)
 **Quick start:**
 ```
 pip install -e ~/code/toolbox/
-source ~/.world/pulse/env   # or export GH_TOKEN=...
+export $(grep -v '^#' ~/.world/pulse/env | xargs)   # load and export token
 pulse --now                  # run snapshot + render digest
 pulse --self-check           # validate token, config, storage
 ```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Full documentation: [`pulse/README.md`](pulse/README.md)
 
 **Quick start:**
 ```bash
-pip install -e ~/code/toolbox/
+~/venvs/transcribe/bin/pip install -e ~/code/toolbox/
 mkdir -p ~/.world/pulse && chmod 700 ~/.world/pulse
 echo "GH_TOKEN=ghp_yourtoken" > ~/.world/pulse/env && chmod 600 ~/.world/pulse/env
 cp ~/code/toolbox/systemd/user/config.yml ~/.world/pulse/config.yml

--- a/README.md
+++ b/README.md
@@ -119,41 +119,25 @@ md-speak --no-describe document.md      # skip AI descriptions
 
 ### pulse
 
-CLI tool for snapshotting GitHub org activity. Queries open PRs, issues, releases, and Dependabot PR counts across all repos in configured orgs. Stores rolling 7-day history in SQLite; exports JSON + markdown digest.
+GitHub org activity monitor. Periodic GraphQL snapshots — open PRs, issues, Dependabot PRs, releases — stored in SQLite, rendered to a markdown digest.
 
-**Setup:**
-- `GH_TOKEN` in `~/.world/pulse/env` (chmod 600). Token needs `repo`, `read:org` scopes.
-- `~/.world/pulse/config.yml` — see `pulse/` package for schema. Create with:
-  ```yaml
-  schema_version: "1.0"
-  orgs:
-    claudes-world:
-      ignore: []
-  defaults:
-    stall_pr_hours: 12
-    stall_issue_hours: 72
-    history_days: 7
-    cadence_minutes: 30
-    github_api_base: "https://api.github.com"
-    max_prs_per_repo: 30
-    max_issues_per_repo: 50
-    max_releases_per_repo: 10
-  ```
-- Install: `pip install -e ~/code/toolbox/` (installs `pulse` CLI entry point)
+Full documentation: [`pulse/README.md`](pulse/README.md)
 
-**Usage:**
+**Quick start:**
 ```
-pulse --config-check          # validate config + print effective config
-pulse --self-check            # config + storage + writability health check
-pulse --version
+pip install -e ~/code/toolbox/
+source ~/.world/pulse/env   # or export GH_TOKEN=...
+pulse --now                  # run snapshot + render digest
+pulse --self-check           # validate token, config, storage
 ```
 
 **Files:**
-- `pulse/` — Python package (config, storage, ipv4 patch)
+- `pulse/` — Python package (config, storage, GraphQL, snapshot, digest)
 - `bin/pulse` — executable entry point
+- `systemd/user/` — service + timer units
 - `tests/test_config.py`, `tests/test_storage.py` — unit tests
 
-**Cost:** No paid API calls in scaffold phase. GraphQL queries use GitHub PAT (free tier).
+**Cost:** No paid API calls. GraphQL queries use GitHub PAT (free tier).
 
 ---
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -66,7 +66,7 @@ For hooks that block the event pipeline (`UserPromptSubmit`): exit code 2 cancel
 2. Make it executable: `chmod +x hooks/<hook-name>`
 3. Source `common.sh` if it needs a Telegram chat ID
 4. Add a row to the registry table above
-5. Wire it in `.claude/settings.json` (or the project's `settings.local.json`):
+5. Wire it in `.claude/settings.json` (or the project's `.claude/settings.local.json`):
    ```json
    {
      "hooks": {

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,6 +1,6 @@
 # hooks
 
-Claude Code event-driven scripts. Each hook fires on a specific Claude Code lifecycle event and receives JSON on stdin (where applicable). Hooks live in `hooks/` and are wired via `.claude/settings.json` or `settings.local.json`.
+Claude Code event-driven scripts. Each hook fires on a specific Claude Code lifecycle event and receives JSON on stdin (where applicable). Hooks live in `hooks/` and are wired via `.claude/settings.json` or `.claude/settings.local.json`.
 
 ## Hook registry
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -58,7 +58,7 @@ Hook scripts receive event JSON on stdin (where applicable). Output must be JSON
 }
 ```
 
-For hooks that block the event pipeline (`UserPromptSubmit`), a non-zero exit code cancels the action. See [Claude Code hooks docs](https://docs.anthropic.com/en/docs/claude-code/hooks) for the full schema per event type.
+For hooks that block the event pipeline (`UserPromptSubmit`): exit code 2 cancels the action and surfaces the hook's stderr to the model; exit code 0 continues normally; other non-zero exit codes are treated as non-blocking errors. See [Claude Code hooks docs](https://docs.anthropic.com/en/docs/claude-code/hooks) for the full schema per event type.
 
 ## Adding a hook
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,83 @@
+# hooks
+
+Claude Code event-driven scripts. Each hook fires on a specific Claude Code lifecycle event and receives JSON on stdin (where applicable). Hooks live in `hooks/` and are wired via `.claude/settings.json` or `settings.local.json`.
+
+## Hook registry
+
+| Hook Name | Event | Purpose | Status |
+|-----------|-------|---------|--------|
+| `actions-hook` | `UserPromptSubmit` | Handle Actions keyboard button taps; show one-time reply keyboard, execute action, restore launcher | Active |
+| `agent-start-hook` | `SubagentStart` | Notify Telegram and track active agent in JSON state file | Active |
+| `agent-stop-hook` | `SubagentStop` | Notify Telegram (threaded) and update agent tracker | Active |
+| `compact-hook` | `PreCompact` / `PostCompact` | Notify user on Telegram before and after context compaction | Active |
+| `context-threshold-check` | `UserPromptSubmit` | Estimate context utilization from transcript JSONL; nudge pre-compact preparation | Active |
+| `launcher-hook` | `SessionStart` | Restore the web_app keyboard launcher; initialize `.active-chat` if absent | Active |
+| `quarantine-research` | manual / Bash | Isolated Claude subprocess research pipeline with sanitizer + Haiku review + risk-gated release | Active |
+| `safe-research` | manual / Bash | Sandboxed web research via restricted `claude -p`; pipes through sanitizer | Active |
+| `sanitize-research` | called by quarantine-research | Scan research output for prompt injection patterns; prepend warnings | Active |
+| `share-doc` | manual / Bash | Write markdown to timestamped file in `~/claudes-world/tmp/` and send Telegram deep-link button | Active |
+| `typing-hook` | `UserPromptSubmit` | Send typing indicator on every inbound Telegram message; write `.active-chat` | Active |
+| `voice-hook` | `UserPromptSubmit` | Auto-transcribe Telegram voice notes; reply with transcription; inject into context | Active |
+| `worktree-add-port-init` | `PostToolUse` (Bash) | On `git worktree add`, run `port-for --init` for new worktree | Active |
+| `worktree-remove-port-release` | `PostToolUse` (Bash) | On `git worktree remove`, run `port-for --release-worktree` | Active |
+
+## Shared utilities
+
+### `hooks/common.sh`
+
+Source at the top of any hook that needs to send Telegram messages:
+
+```bash
+. "$(dirname "$0")/common.sh"
+# Sets: BOTTOKEN, TELEGRAM_CHAT_ID (or HOOK_ERROR if unresolvable)
+```
+
+**Chat ID priority chain** (first non-empty wins):
+
+1. Project-scoped `.claude/.active-chat` (written by `typing-hook` on each inbound message)
+2. `TELEGRAM_CHAT_ID` env var (from `settings.local.json` env block)
+3. `~/.secrets/telegram.env` global secrets file
+4. First entry in `~/.claude/channels/telegram/access.json` allowlist
+
+If all four fail, `HOOK_ERROR` is set with a diagnostic message. Use `require_chat_id || exit 0` to emit this as `additionalContext` for the model.
+
+### `hooks/lib/launcher-keyboard.sh`
+
+Keyboard state management for the Telegram web_app launcher button. Sourced by `launcher-hook` and `actions-hook`. Handles: keyboard creation, state persistence, and restoration after action execution.
+
+## Hook I/O schema
+
+Hook scripts receive event JSON on stdin (where applicable). Output must be JSON with a `hookSpecificOutput` field:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "Transcription: hello world"
+  }
+}
+```
+
+For hooks that block the event pipeline (`UserPromptSubmit`), a non-zero exit code cancels the action. See [Claude Code hooks docs](https://docs.anthropic.com/en/docs/claude-code/hooks) for the full schema per event type.
+
+## Adding a hook
+
+1. Create the script in `hooks/<hook-name>` with a shebang (`#!/bin/bash` or `#!/path/to/python3`)
+2. Make it executable: `chmod +x hooks/<hook-name>`
+3. Source `common.sh` if it needs a Telegram chat ID
+4. Add a row to the registry table above
+5. Wire it in `.claude/settings.json` (or the project's `settings.local.json`):
+   ```json
+   {
+     "hooks": {
+       "UserPromptSubmit": [{
+         "hooks": [{
+           "type": "command",
+           "command": "/home/claude/code/toolbox/hooks/<hook-name>",
+           "timeout": 30
+         }]
+       }]
+     }
+   }
+   ```
+6. Test with a real Claude Code session; check stderr for errors

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -23,14 +23,16 @@ echo "GH_TOKEN=ghp_yourtoken" > ~/.world/pulse/env
 chmod 600 ~/.world/pulse/env
 ```
 
-The systemd service automatically loads this file via `EnvironmentFile=`. For manual CLI use, source it first:
+The systemd service automatically loads this file via `EnvironmentFile=`. For manual CLI use, export the token into your shell:
 
 ```bash
-source ~/.world/pulse/env
+export $(grep -v '^#' ~/.world/pulse/env | xargs)
 pulse --now
 ```
 
-Or export inline: `GH_TOKEN=$(grep GH_TOKEN ~/.world/pulse/env | cut -d= -f2) pulse --now`
+Or inline: `GH_TOKEN=$(grep GH_TOKEN ~/.world/pulse/env | cut -d= -f2) pulse --now`
+
+Note: `source ~/.world/pulse/env` assigns variables but does not export them to child processes unless you follow with `export GH_TOKEN`.
 
 Token needs `read:org` + `repo` scopes (classic PAT) or equivalent fine-grained permissions.
 

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -8,7 +8,24 @@ GitHub org health monitor. Periodic GraphQL snapshots across configured orgs, st
 
 **Note (v0 scope):** The `alerts` table in the schema is a stub for future Dependabot security-alert integration (GitHub GraphQL `vulnerabilityAlerts`). In v0 the Dependabot section of the digest shows open Dependabot bot PRs (derived from PR author), not raw security alerts.
 
-## Installation
+## Quick start
+
+Run the installer from the toolbox root — it handles everything:
+
+```bash
+cd ~/code/toolbox
+./install.sh
+```
+
+The installer:
+1. Creates `~/.world/pulse/` with correct permissions
+2. Copies systemd unit files + reloads daemon
+3. Runs `pulse --self-check` to validate token + config
+4. Enables and starts `pulse.timer`
+
+After install, edit `~/.world/pulse/config.yml` to add your org(s), then run `pulse --now` to take the first snapshot.
+
+## Manual setup (advanced)
 
 ```bash
 ~/venvs/transcribe/bin/pip install -e ~/code/toolbox/

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -1,10 +1,12 @@
 # pulse
 
-GitHub org health monitor. Periodic GraphQL snapshots across configured orgs, stored in SQLite, rendered to a markdown digest. Tracks open PRs, issues, Dependabot alerts, and recent releases.
+GitHub org health monitor. Periodic GraphQL snapshots across configured orgs, stored in SQLite, rendered to a markdown digest. Tracks open PRs (including Dependabot bot PRs), issues, and recent releases.
 
 ## Overview
 
-`pulse` runs as a systemd user timer (every 30 minutes by default) and on demand via `pulse --now`. Each snapshot queries the GitHub GraphQL API, writes results to `~/.world/pulse/pulse.db`, and renders a human-readable markdown digest at `~/.world/pulse/snapshots/digest-latest.md`. Stalled PRs (idle beyond threshold), open security alerts, and recent releases are all surfaced in one place without manual polling.
+`pulse` runs as a systemd user timer (every 30 minutes by default) and on demand via `pulse --now`. Each snapshot queries the GitHub GraphQL API, writes results to `~/.world/pulse/pulse.db`, and renders a human-readable markdown digest at `~/.world/pulse/snapshots/digest-latest.md`. Stalled PRs (idle beyond threshold), Dependabot PRs, and recent releases are all surfaced in one place without manual polling.
+
+**Note (v0 scope):** The `alerts` table in the schema is a stub for future Dependabot security-alert integration (GitHub GraphQL `vulnerabilityAlerts`). In v0 the Dependabot section of the digest shows open Dependabot bot PRs (derived from PR author), not raw security alerts.
 
 ## Installation
 
@@ -83,7 +85,7 @@ Location: `~/.world/pulse/pulse.db` (0o600). WAL mode, `busy_timeout=5000ms`.
 | `prs` | `repo_id`, `number`, `title`, `author`, `created_at`, `updated_at`, `is_draft`, `is_dependabot`, `is_renovate`, `hours_idle`, `stalled` | Open PRs at snapshot time |
 | `issues` | `repo_id`, `number`, `title`, `author`, `created_at`, `updated_at`, `labels`, `hours_idle`, `stalled` | Open issues at snapshot time |
 | `releases` | `repo_id`, `tag_name`, `name`, `created_at`, `is_prerelease` | Releases within history window |
-| `alerts` | `repo_id`, `severity`, `ghsa_id`, `package_name`, `ecosystem`, `age_days`, `dependabot_pr_number` | Dependabot security alerts |
+| `alerts` | `repo_id`, `severity`, `ghsa_id`, `package_name`, `ecosystem`, `age_days`, `dependabot_pr_number` | Dependabot security alerts (schema stub — not populated in v0) |
 | `pagination_state` | `org`, `repo`, `field`, `last_cursor`, `timestamp` | Cursor state for incremental pagination |
 
 Full schema: `pulse/storage.py` → `create_schema()`.

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -12,6 +12,8 @@ GitHub org health monitor. Periodic GraphQL snapshots across configured orgs, st
 
 Run the installer from the toolbox root — it handles everything:
 
+> **First run only:** if `~/.world/pulse/env` doesn't exist, `install.sh` creates an empty one and stops — edit it to add your `GH_TOKEN`, then re-run `./install.sh`.
+
 ```bash
 cd ~/code/toolbox
 ./install.sh

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -19,6 +19,7 @@ This installs the `pulse` CLI entry point (defined in `pyproject.toml`). The sys
 GH_TOKEN must be set in `~/.world/pulse/env` (0o600):
 
 ```bash
+mkdir -p ~/.world/pulse && chmod 700 ~/.world/pulse
 echo "GH_TOKEN=ghp_yourtoken" > ~/.world/pulse/env
 chmod 600 ~/.world/pulse/env
 ```
@@ -29,8 +30,6 @@ The systemd service automatically loads this file via `EnvironmentFile=`. For ma
 export $(grep -v '^#' ~/.world/pulse/env | xargs)
 pulse --now
 ```
-
-Or inline: `GH_TOKEN=$(grep GH_TOKEN ~/.world/pulse/env | cut -d= -f2) pulse --now`
 
 Note: `source ~/.world/pulse/env` assigns variables but does not export them to child processes unless you follow with `export GH_TOKEN`.
 

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -12,9 +12,10 @@ GitHub org health monitor. Periodic GraphQL snapshots across configured orgs, st
 
 ```bash
 ~/venvs/transcribe/bin/pip install -e ~/code/toolbox/
+ln -sf ~/code/toolbox/bin/pulse ~/bin/pulse   # add to PATH
 ```
 
-This installs the `pulse` CLI entry point into the shared `~/venvs/transcribe/` venv (defined in `pyproject.toml`). The `bin/pulse` shebang is hardcoded to that venv's interpreter. The systemd unit files live in `~/code/toolbox/systemd/`.
+This installs pulse's dependencies into the shared `~/venvs/transcribe/` venv (defined in `pyproject.toml`). The `bin/pulse` entry point has its shebang hardcoded to that venv's interpreter. Symlinking into `~/bin/` makes `pulse` available on `PATH`. The systemd unit files live in `~/code/toolbox/systemd/`.
 
 GH_TOKEN must be set in `~/.world/pulse/env` (0o600):
 

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -86,17 +86,18 @@ Location: `~/.world/pulse/pulse.db` (0o600). WAL mode, `busy_timeout=5000ms`.
 | `issues` | `repo_id`, `number`, `title`, `author`, `created_at`, `updated_at`, `labels`, `hours_idle`, `stalled` | Open issues at snapshot time |
 | `releases` | `repo_id`, `tag_name`, `name`, `created_at`, `is_prerelease` | Releases within history window |
 | `alerts` | `repo_id`, `severity`, `ghsa_id`, `package_name`, `ecosystem`, `age_days`, `dependabot_pr_number` | Dependabot security alerts (schema stub — not populated in v0) |
-| `pagination_state` | `org`, `repo`, `field`, `last_cursor`, `timestamp` | Cursor state for incremental pagination |
+| `pagination_state` | `org`, `repo`, `field`, `last_cursor`, `timestamp` | Cursor state for org-level repo enumeration (not per-repo collections) |
 
 Full schema: `pulse/storage.py` → `create_schema()`.
 
 ## GraphQL design notes
 
 - GitHub GraphQL v4 API (`https://api.github.com/graphql`)
-- One paginated query per collection per repo (PRs, issues, releases, alerts)
-- `first: 100` cap per page; `pagination_state` table stores cursors for incremental fetches
-- Stale or truncated data surfaced as `partial` capture_status on the repo row — never silently dropped
-- IPv4 monkey-patch applied at startup (same pattern as `smart-speak`) — VPS Happy Eyeballs stall workaround
+- **Org-level repo enumeration** uses cursor pagination (`gql.paginate`) to page through all repos in an org (50 per page).
+- **Per-repo collections** (PRs, issues, releases) use a single capped query per collection (`gql.execute` with `first: max_*_per_repo`, clamped to 100). If the real count exceeds the cap, the repo is marked `partial` — data shown is real but may be incomplete.
+- `pagination_state` table stores org-level repo cursors (not per-repo PR/issue cursors).
+- Stale or truncated data surfaced as `partial` capture_status on the repo row — never silently dropped.
+- IPv4 monkey-patch applied at startup (same pattern as `smart-speak`) — VPS Happy Eyeballs stall workaround.
 
 ## GH_TOKEN scope requirements
 

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -1,0 +1,131 @@
+# pulse
+
+GitHub org health monitor. Periodic GraphQL snapshots across configured orgs, stored in SQLite, rendered to a markdown digest. Tracks open PRs, issues, Dependabot alerts, and recent releases.
+
+## Overview
+
+`pulse` runs as a systemd user timer (every 30 minutes by default) and on demand via `pulse --now`. Each snapshot queries the GitHub GraphQL API, writes results to `~/.world/pulse/pulse.db`, and renders a human-readable markdown digest at `~/.world/pulse/snapshots/digest-latest.md`. Stalled PRs (idle beyond threshold), open security alerts, and recent releases are all surfaced in one place without manual polling.
+
+## Installation
+
+```bash
+pip install -e ~/code/toolbox/
+```
+
+This installs the `pulse` CLI entry point (defined in `pyproject.toml`). The systemd unit files live in `~/code/toolbox/systemd/`.
+
+GH_TOKEN must be set in `~/.world/pulse/env` (0o600):
+
+```bash
+echo "GH_TOKEN=ghp_yourtoken" > ~/.world/pulse/env
+chmod 600 ~/.world/pulse/env
+```
+
+Token needs `read:org` + `repo` scopes (classic PAT) or equivalent fine-grained permissions.
+
+## Configuration
+
+Config lives at `~/.world/pulse/config.yml`. Validated on load via Pydantic (`pulse/config.py`).
+
+```yaml
+schema_version: "1.0"
+
+orgs:
+  claudes-world:            # GitHub org name
+    ignore: []              # repo names to skip entirely
+    stall_overrides:        # per-repo stall threshold overrides (optional)
+      some-repo:
+        pr_hours: 24        # override stall_pr_hours for this repo
+        issue_hours: 168    # override stall_issue_hours for this repo
+
+defaults:
+  stall_pr_hours: 12        # flag PRs idle > this many hours
+  stall_issue_hours: 72     # flag issues idle > this many hours
+  history_days: 7           # SQLite retention window (1-365)
+  cadence_minutes: 30       # informational; systemd timer governs actual schedule
+  github_api_base: "https://api.github.com"
+  max_prs_per_repo: 30      # GraphQL pagination cap per repo
+  max_issues_per_repo: 50
+  max_releases_per_repo: 10
+```
+
+Key Pydantic model classes (see `pulse/config.py`):
+
+| Class | Fields |
+|-------|--------|
+| `PulseConfig` | `schema_version`, `orgs`, `defaults` |
+| `OrgConfig` | `ignore` (list), `stall_overrides` (dict of repo → `StallOverride`) |
+| `StallOverride` | `pr_hours`, `issue_hours` |
+| `Defaults` | all defaults fields above |
+
+Unknown keys are rejected (`extra="forbid"`).
+
+## CLI subcommands
+
+| Command | Description |
+|---------|-------------|
+| `pulse --now` | Run snapshot + render digest. Manual path — acquires file lock, blocks until complete. |
+| `pulse --service` | Run snapshot without lock. Used by systemd `ExecStart`. |
+| `pulse --digest` | Print current digest to stdout. No new snapshot. |
+| `pulse --self-check` | Diagnostic: verify token scope, config parse, directory permissions, SQLite integrity. |
+| `pulse --dry-run [--repo OWNER/NAME]` | Test against a single repo, write to `/tmp`. No DB writes. |
+| `pulse --config-check` | Validate config + print effective YAML. Exits non-zero on error. |
+| `pulse --version` | Print version. |
+
+## SQLite storage
+
+Location: `~/.world/pulse/pulse.db` (0o600). WAL mode, `busy_timeout=5000ms`.
+
+| Table | Key columns | Purpose |
+|-------|-------------|---------|
+| `snapshots` | `id`, `captured_at_utc`, `captured_at_et`, `duration_ms`, `orgs_queried`, `repos_succeeded`, `repos_failed`, `repos_partial`, `capture_status` | One row per snapshot run |
+| `repos` | `snapshot_id`, `org`, `name`, `default_branch`, `is_fork`, `is_archived`, `capture_status`, `field_statuses` | Repos queried in each snapshot |
+| `prs` | `repo_id`, `number`, `title`, `author`, `created_at`, `updated_at`, `is_draft`, `is_dependabot`, `is_renovate`, `hours_idle`, `stalled` | Open PRs at snapshot time |
+| `issues` | `repo_id`, `number`, `title`, `author`, `created_at`, `updated_at`, `labels`, `hours_idle`, `stalled` | Open issues at snapshot time |
+| `releases` | `repo_id`, `tag_name`, `name`, `created_at`, `is_prerelease` | Releases within history window |
+| `alerts` | `repo_id`, `severity`, `ghsa_id`, `package_name`, `ecosystem`, `age_days`, `dependabot_pr_number` | Dependabot security alerts |
+| `pagination_state` | `org`, `repo`, `field`, `last_cursor`, `timestamp` | Cursor state for incremental pagination |
+
+Full schema: `pulse/storage.py` → `create_schema()`.
+
+## GraphQL design notes
+
+- GitHub GraphQL v4 API (`https://api.github.com/graphql`)
+- One paginated query per collection per repo (PRs, issues, releases, alerts)
+- `first: 100` cap per page; `pagination_state` table stores cursors for incremental fetches
+- Stale or truncated data surfaced as `partial` capture_status on the repo row — never silently dropped
+- IPv4 monkey-patch applied at startup (same pattern as `smart-speak`) — VPS Happy Eyeballs stall workaround
+
+## GH_TOKEN scope requirements
+
+| PAT type | Scopes needed |
+|----------|--------------|
+| Classic PAT | `read:org`, `repo` |
+| Fine-grained PAT | `Contents: read`, `Issues: read`, `Pull requests: read`, `Metadata: read`, `Members: read` (per org) |
+
+Verify with: `pulse --self-check`
+
+## Troubleshooting
+
+**Run the built-in diagnostic first:**
+```bash
+pulse --self-check
+```
+
+**Check service logs:**
+```bash
+journalctl --user -u pulse.service -n 50
+journalctl --user -u pulse.timer
+```
+
+**Test config validity:**
+```bash
+pulse --config-check
+```
+
+**Dry run against a specific repo:**
+```bash
+pulse --dry-run --repo claudes-world/toolbox
+```
+
+For full operational procedures (token rotation, adding orgs, security guidance), see the SOP at `~/claudes-world/knowledge/sop/org-pulse.md`.

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -24,11 +24,19 @@ echo "GH_TOKEN=ghp_yourtoken" > ~/.world/pulse/env
 chmod 600 ~/.world/pulse/env
 ```
 
-The systemd service automatically loads this file via `EnvironmentFile=`. For manual CLI use, export the token into your shell:
+Config must also exist before running pulse:
+
+```bash
+cp ~/code/toolbox/systemd/user/config.yml ~/.world/pulse/config.yml
+# Edit to set your org(s) under `orgs:`
+```
+
+The systemd service automatically loads the env file via `EnvironmentFile=`. For manual CLI use, export the token into your shell:
 
 ```bash
 export $(grep -v '^#' ~/.world/pulse/env | xargs)
-pulse --now
+pulse --self-check    # verify setup
+pulse --now           # run snapshot + render digest
 ```
 
 Note: `source ~/.world/pulse/env` assigns variables but does not export them to child processes unless you follow with `export GH_TOKEN`.

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -23,6 +23,15 @@ echo "GH_TOKEN=ghp_yourtoken" > ~/.world/pulse/env
 chmod 600 ~/.world/pulse/env
 ```
 
+The systemd service automatically loads this file via `EnvironmentFile=`. For manual CLI use, source it first:
+
+```bash
+source ~/.world/pulse/env
+pulse --now
+```
+
+Or export inline: `GH_TOKEN=$(grep GH_TOKEN ~/.world/pulse/env | cut -d= -f2) pulse --now`
+
 Token needs `read:org` + `repo` scopes (classic PAT) or equivalent fine-grained permissions.
 
 ## Configuration
@@ -46,7 +55,7 @@ defaults:
   history_days: 7           # SQLite retention window (1-365)
   cadence_minutes: 30       # informational; systemd timer governs actual schedule
   github_api_base: "https://api.github.com"
-  max_prs_per_repo: 30      # GraphQL pagination cap per repo
+  max_prs_per_repo: 30      # max PRs fetched per repo (single capped query, not cursor pagination)
   max_issues_per_repo: 50
   max_releases_per_repo: 10
 ```
@@ -84,7 +93,7 @@ Location: `~/.world/pulse/pulse.db` (0o600). WAL mode, `busy_timeout=5000ms`.
 | `repos` | `snapshot_id`, `org`, `name`, `default_branch`, `is_fork`, `is_archived`, `capture_status`, `field_statuses` | Repos queried in each snapshot |
 | `prs` | `repo_id`, `number`, `title`, `author`, `created_at`, `updated_at`, `is_draft`, `is_dependabot`, `is_renovate`, `hours_idle`, `stalled` | Open PRs at snapshot time |
 | `issues` | `repo_id`, `number`, `title`, `author`, `created_at`, `updated_at`, `labels`, `hours_idle`, `stalled` | Open issues at snapshot time |
-| `releases` | `repo_id`, `tag_name`, `name`, `created_at`, `is_prerelease` | Releases within history window |
+| `releases` | `repo_id`, `tag_name`, `name`, `created_at`, `is_prerelease` | Latest N releases per repo (`max_releases_per_repo`); `history_days` governs snapshot retention, not release filtering |
 | `alerts` | `repo_id`, `severity`, `ghsa_id`, `package_name`, `ecosystem`, `age_days`, `dependabot_pr_number` | Dependabot security alerts (schema stub — not populated in v0) |
 | `pagination_state` | `org`, `repo`, `field`, `last_cursor`, `timestamp` | Cursor state for org-level repo enumeration (not per-repo collections) |
 

--- a/pulse/README.md
+++ b/pulse/README.md
@@ -11,10 +11,10 @@ GitHub org health monitor. Periodic GraphQL snapshots across configured orgs, st
 ## Installation
 
 ```bash
-pip install -e ~/code/toolbox/
+~/venvs/transcribe/bin/pip install -e ~/code/toolbox/
 ```
 
-This installs the `pulse` CLI entry point (defined in `pyproject.toml`). The systemd unit files live in `~/code/toolbox/systemd/`.
+This installs the `pulse` CLI entry point into the shared `~/venvs/transcribe/` venv (defined in `pyproject.toml`). The `bin/pulse` shebang is hardcoded to that venv's interpreter. The systemd unit files live in `~/code/toolbox/systemd/`.
 
 GH_TOKEN must be set in `~/.world/pulse/env` (0o600):
 

--- a/systemd/user/config.yml
+++ b/systemd/user/config.yml
@@ -5,8 +5,9 @@ orgs: {}  # Add your GitHub org(s) — see example below
 #   stall_overrides: {}
 defaults:
   github_api_base: "https://api.github.com"
-  stall_pr_hours: 48.0
-  stall_issue_hours: 168.0
+  stall_pr_hours: 12
+  stall_issue_hours: 72
+  cadence_minutes: 30
   max_prs_per_repo: 30
   max_issues_per_repo: 50
   max_releases_per_repo: 10


### PR DESCRIPTION
## Summary

Documentation and discoverability layer for the org-pulse monitor (v0).

- `.claude/skills/pulse/SKILL.md` — `/pulse` skill invocation (in claudes-world repo)
- `knowledge/sop/org-pulse.md` — full install→run→debug→rotate lifecycle SOP (in claudes-world repo)
- `knowledge/adr/0015-org-pulse.md` — decision record + pulse-source interface note (in claudes-world repo)
- `pulse/README.md` — package config, CLI, storage, GraphQL, troubleshooting
- `hooks/README.md` — hook ecosystem registry (starter)
- `README.md` — updated with Additional tools section + hooks/pulse links
- `AGENTS.md` — updated with Python package + hook addition guidelines, ADR refs

## Test plan

- [x] All 7 deliverables present
- [x] Cross-links audited and resolve (ADRs 0003/0006/0014/0015, plan rev3, research docs)
- [x] No secrets in committed docs (placeholder tokens only in examples)
- [x] ADR 0015 includes pulse-source interface note verbatim
- [x] Local swarm clean (Tier 1 self-review pass)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)