### PR TITLE
feat(pulse): v1 PR review-event timeline collection (#47)

### DIFF
--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import sys
 import time
+from collections.abc import Callable
 
 import httpx
 
@@ -62,6 +63,11 @@ class RunDeadlineExceeded(Exception):
 
 
 class CostBudgetExceeded(Exception):
+    pass
+
+
+class PRNodeNotFound(Exception):
+    """Raised when a PR node_id is not found on GitHub (data.node=null)."""
     pass
 
 
@@ -264,6 +270,7 @@ class GraphQLClient:
         field: str = "",
         cursor_var: str = "cursor",
         fingerprint: str = "",
+        on_page_response: Callable[[dict], None] | None = None,
     ) -> list[dict]:
         """Walk a paginated GraphQL connection, returning all collected nodes.
 
@@ -301,6 +308,12 @@ class GraphQLClient:
         try:
             while True:
                 body = self.execute(query, variables, deadline_monotonic=deadline_monotonic)
+
+                if on_page_response is not None:
+                    try:
+                        on_page_response(body)
+                    except Exception:
+                        pass  # callback failure must not interrupt pagination
 
                 try:
                     page_info: dict = body
@@ -390,6 +403,21 @@ class GraphQLClient:
         cumulative_cost: caller-supplied single-element list used as a mutable
         integer accumulator. Pass [0] to enable cross-PR cost tracking.
         """
+        accumulated_cost = [0]
+        last_remaining = [5000]
+        node_not_found = [False]
+
+        def _on_page(resp: dict) -> None:
+            data = resp.get("data") or {}
+            if data.get("node") is None and "node" in data:
+                node_not_found[0] = True
+            rate = data.get("rateLimit") or {}
+            page_cost = rate.get("cost", 0)
+            accumulated_cost[0] += page_cost
+            remaining = rate.get("remaining")
+            if remaining is not None:
+                last_remaining[0] = remaining
+
         nodes = self.paginate(
             query=PR_TIMELINE_QUERY,
             variables={"prId": pr_node_id, "cursor": None},
@@ -397,47 +425,31 @@ class GraphQLClient:
             nodes_path=["data", "node", "timelineItems", "nodes"],
             deadline_monotonic=deadline_monotonic,
             cursor_var="cursor",
+            on_page_response=_on_page,
         )
 
-        # Track cumulative cost from the last response (rateLimit is in each page body).
-        # We re-execute a small extra call to get cost when paginate() completes. Instead,
-        # we track it inline by wrapping execute(). Since paginate() already called execute(),
-        # we piggyback cost via a separate last-query cost read. For simplicity, we call
-        # a single extra non-paginated query only if cumulative tracking is requested.
-        # Actually: paginate() calls execute() which already logs cost per call. We track
-        # cumulative by reading rateLimit from each response. Since paginate() abstracts
-        # execute(), we do one more execute() call here only for cost — wasteful. Better:
-        # pass a cost callback. For now, use a single post-paginate cost probe only when
-        # cumulative_cost is provided.
+        if node_not_found[0]:
+            raise PRNodeNotFound(f"PR node_id not found on GitHub: {pr_node_id}")
+
         if cumulative_cost is not None:
-            try:
-                probe = self.execute(
-                    "query { rateLimit { cost remaining } }",
-                    deadline_monotonic=deadline_monotonic,
+            cost = accumulated_cost[0]
+            remaining = last_remaining[0]
+            cumulative_cost[0] += cost
+            if cost > TIMELINE_COST_WARN:
+                print(
+                    f"WARNING: timeline query cost {cost} exceeds threshold {TIMELINE_COST_WARN}",
+                    file=sys.stderr,
                 )
-                rate = (probe.get("data") or {}).get("rateLimit") or {}
-                cost = rate.get("cost", 1)
-                remaining = rate.get("remaining", 5000)
-                cumulative_cost[0] += cost
-                if cost > TIMELINE_COST_WARN:
-                    print(
-                        f"WARNING: timeline query cost {cost} exceeds threshold {TIMELINE_COST_WARN}",
-                        file=sys.stderr,
-                    )
-                if remaining < 100:
-                    print(
-                        f"CRITICAL: rateLimit.remaining={remaining} — approaching rate limit",
-                        file=sys.stderr,
-                    )
-                if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
-                    raise CostBudgetExceeded(
-                        f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
-                        "skipping remaining timeline fetches for this run"
-                    )
-            except CostBudgetExceeded:
-                raise
-            except Exception:
-                pass  # cost tracking failure is non-fatal
+            if remaining < 100:
+                print(
+                    f"CRITICAL: rateLimit.remaining={remaining} — approaching rate limit",
+                    file=sys.stderr,
+                )
+            if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+                raise CostBudgetExceeded(
+                    f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
+                    "skipping remaining timeline fetches for this run"
+                )
 
         return nodes
 

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -66,7 +66,9 @@ class RunDeadlineExceeded(Exception):
 
 
 class CostBudgetExceeded(Exception):
-    pass
+    def __init__(self, message: str, cost: int = 0) -> None:
+        super().__init__(message)
+        self.cost = cost
 
 
 class PRNodeNotFound(Exception):
@@ -183,7 +185,8 @@ class GraphQLClient:
                 # Callers should aggregate rateLimit.cost across calls if a run budget is needed.
                 if cost > COST_ABORT_THRESHOLD:
                     raise CostBudgetExceeded(
-                        f"query cost {cost} exceeds abort threshold {COST_ABORT_THRESHOLD}"
+                        f"query cost {cost} exceeds abort threshold {COST_ABORT_THRESHOLD}",
+                        cost=cost,
                     )
                 if cost > COST_WARN_THRESHOLD:
                     print(
@@ -447,6 +450,10 @@ class GraphQLClient:
                 cursor_var="cursor",
                 on_page_response=_on_page,
             )
+        except CostBudgetExceeded as e:
+            # execute() raised before on_page_response ran — accumulate the aborting page's cost
+            accumulated_cost[0] += getattr(e, "cost", 0)
+            raise
         finally:
             # Pure accumulation only — NEVER raise from finally (would mask paginate exceptions)
             if cumulative_cost is not None:

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -13,6 +13,41 @@ COST_WARN_THRESHOLD = 10
 COST_ABORT_THRESHOLD = 50
 DEFAULT_DEADLINE_SEC = int(os.environ.get("PULSE_RUN_DEADLINE_SEC", "1200"))
 
+# Per-query cost thresholds for timeline fetches
+TIMELINE_COST_WARN = 100
+# Cumulative budget guard: warn + skip remaining timeline fetches above this point
+TIMELINE_CUMULATIVE_WARN = 4500
+
+PR_TIMELINE_QUERY = """
+query($prId: ID!, $cursor: String) {
+  node(id: $prId) {
+    ... on PullRequest {
+      timelineItems(first: 100, after: $cursor, itemTypes: [
+        REVIEW_REQUESTED_EVENT,
+        PULL_REQUEST_REVIEW,
+        MERGED_EVENT,
+        CLOSED_EVENT,
+        LABELED_EVENT,
+        REFERENCED_EVENT
+      ]) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          __typename
+          ... on PullRequestReview { author { login } state submittedAt }
+          ... on ReviewRequestedEvent { actor { login } createdAt }
+          ... on MergedEvent { actor { login } createdAt }
+          ... on ClosedEvent { actor { login } createdAt }
+          ... on LabeledEvent { actor { login } createdAt label { name } }
+          ... on ReferencedEvent { actor { login } createdAt }
+        }
+      }
+    }
+  }
+  rateLimit { cost remaining }
+}
+"""
+
 
 class RetriesExhausted(Exception):
     pass
@@ -338,3 +373,71 @@ class GraphQLClient:
             # All other cases: preserve checkpoint for next-run resume
 
         return nodes
+
+    def fetch_pr_timeline(
+        self,
+        pr_node_id: str,
+        deadline_monotonic: float | None = None,
+        cumulative_cost: list[int] | None = None,
+    ) -> list[dict]:
+        """Fetch all timeline events for a PR, paginating if needed.
+
+        Returns list of raw event dicts. Raises CostBudgetExceeded if the
+        cumulative cost across all timeline queries in the run approaches the
+        hourly budget (TIMELINE_CUMULATIVE_WARN). If pr_node_id is not found
+        (node returns None), returns an empty list.
+
+        cumulative_cost: caller-supplied single-element list used as a mutable
+        integer accumulator. Pass [0] to enable cross-PR cost tracking.
+        """
+        nodes = self.paginate(
+            query=PR_TIMELINE_QUERY,
+            variables={"prId": pr_node_id, "cursor": None},
+            page_info_path=["data", "node", "timelineItems", "pageInfo"],
+            nodes_path=["data", "node", "timelineItems", "nodes"],
+            deadline_monotonic=deadline_monotonic,
+            cursor_var="cursor",
+        )
+
+        # Track cumulative cost from the last response (rateLimit is in each page body).
+        # We re-execute a small extra call to get cost when paginate() completes. Instead,
+        # we track it inline by wrapping execute(). Since paginate() already called execute(),
+        # we piggyback cost via a separate last-query cost read. For simplicity, we call
+        # a single extra non-paginated query only if cumulative tracking is requested.
+        # Actually: paginate() calls execute() which already logs cost per call. We track
+        # cumulative by reading rateLimit from each response. Since paginate() abstracts
+        # execute(), we do one more execute() call here only for cost — wasteful. Better:
+        # pass a cost callback. For now, use a single post-paginate cost probe only when
+        # cumulative_cost is provided.
+        if cumulative_cost is not None:
+            try:
+                probe = self.execute(
+                    "query { rateLimit { cost remaining } }",
+                    deadline_monotonic=deadline_monotonic,
+                )
+                rate = (probe.get("data") or {}).get("rateLimit") or {}
+                cost = rate.get("cost", 1)
+                remaining = rate.get("remaining", 5000)
+                cumulative_cost[0] += cost
+                if cost > TIMELINE_COST_WARN:
+                    print(
+                        f"WARNING: timeline query cost {cost} exceeds threshold {TIMELINE_COST_WARN}",
+                        file=sys.stderr,
+                    )
+                if remaining < 100:
+                    print(
+                        f"CRITICAL: rateLimit.remaining={remaining} — approaching rate limit",
+                        file=sys.stderr,
+                    )
+                if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+                    raise CostBudgetExceeded(
+                        f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
+                        "skipping remaining timeline fetches for this run"
+                    )
+            except CostBudgetExceeded:
+                raise
+            except Exception:
+                pass  # cost tracking failure is non-fatal
+
+        return nodes
+

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import sqlite3
 import sys
@@ -9,6 +10,8 @@ from collections.abc import Callable
 import httpx
 
 from pulse.ipv4 import apply_ipv4_patch
+
+logger = logging.getLogger(__name__)
 
 COST_WARN_THRESHOLD = 10
 COST_ABORT_THRESHOLD = 50
@@ -312,8 +315,10 @@ class GraphQLClient:
                 if on_page_response is not None:
                     try:
                         on_page_response(body)
+                    except PRNodeNotFound:
+                        raise  # null-node sentinel: stop pagination immediately
                     except Exception:
-                        pass  # callback failure must not interrupt pagination
+                        pass  # other callback failures must not interrupt pagination
 
                 try:
                     page_info: dict = body
@@ -347,7 +352,7 @@ class GraphQLClient:
 
                 variables[cursor_var] = end_cursor
 
-        except (RunDeadlineExceeded, RetriesExhausted, CostBudgetExceeded, RuntimeError):
+        except (RunDeadlineExceeded, RetriesExhausted, CostBudgetExceeded, RuntimeError, PRNodeNotFound):
             # Interrupted — save cursor so next run resumes instead of restarting from page 1
             if use_checkpoint and last_cursor:
                 try:
@@ -395,30 +400,43 @@ class GraphQLClient:
     ) -> list[dict]:
         """Fetch all timeline events for a PR, paginating if needed.
 
-        Returns list of raw event dicts. Raises CostBudgetExceeded if the
-        cumulative cost across all timeline queries in the run approaches the
-        hourly budget (TIMELINE_CUMULATIVE_WARN). If pr_node_id is not found
-        (node returns None), returns an empty list.
+        Returns list of raw event dicts. Raises CostBudgetExceeded (pre-fetch)
+        if cumulative cost is already >= TIMELINE_CUMULATIVE_WARN before this
+        call starts. If pr_node_id is not found (node returns None), raises
+        PRNodeNotFound.
 
         cumulative_cost: caller-supplied single-element list used as a mutable
         integer accumulator. Pass [0] to enable cross-PR cost tracking.
-        """
-        accumulated_cost = [0]
-        last_remaining = [5000]
-        node_not_found = [False]
 
+        Cost accounting invariants:
+        - Budget gate fires BEFORE any work; raises immediately if over budget.
+        - finally block ONLY accumulates cost; never raises (would mask paginate errors).
+        - If THIS call pushes over budget, a warning is logged but data is returned;
+          the NEXT call's pre-fetch gate will skip it.
+        """
+        # Pre-fetch gate: skip if already over budget
+        if cumulative_cost is not None and cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+            raise CostBudgetExceeded(
+                f"cumulative timeline cost {cumulative_cost[0]} already >= {TIMELINE_CUMULATIVE_WARN}; "
+                "skipping remaining timeline fetches for this run"
+            )
+
+        accumulated_cost = [0]
         def _on_page(resp: dict) -> None:
             data = resp.get("data") or {}
-            if data.get("node") is None and "node" in data:
-                node_not_found[0] = True
+            # Accumulate cost FIRST so null-node responses don't silently drop their cost.
             rate = data.get("rateLimit") or {}
             page_cost = rate.get("cost", 0)
             accumulated_cost[0] += page_cost
             remaining = rate.get("remaining")
-            if remaining is not None:
-                last_remaining[0] = remaining
+            if remaining is not None and remaining < 100:
+                logger.warning("GitHub rate limit remaining=%d — approaching limit", remaining)
+            # Check for null node AFTER cost accounting, BEFORE any timelineItems traversal.
+            # Raising PRNodeNotFound here causes paginate() to re-raise it (see except clause),
+            # which propagates to our try/finally below — cost already flushed above.
+            if data.get("node") is None and "node" in data:
+                raise PRNodeNotFound(f"PR node_id not found on GitHub: {pr_node_id}")
 
-        # try/finally ensures cost is flushed even if paginate() raises mid-walk
         try:
             nodes = self.paginate(
                 query=PR_TIMELINE_QUERY,
@@ -430,31 +448,22 @@ class GraphQLClient:
                 on_page_response=_on_page,
             )
         finally:
-            # Always flush accumulated cost, even if paginate() raised
+            # Pure accumulation only — NEVER raise from finally (would mask paginate exceptions)
             if cumulative_cost is not None:
                 cumulative_cost[0] += accumulated_cost[0]
-                if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
-                    raise CostBudgetExceeded(
-                        f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
-                        "skipping remaining timeline fetches for this run"
-                    )
 
-        if node_not_found[0]:
-            raise PRNodeNotFound(f"PR node_id not found on GitHub: {pr_node_id}")
+        # Post-fetch: warn if THIS call pushed us over budget (next call's gate will skip)
+        if cumulative_cost is not None and cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+            logger.warning(
+                "Cumulative timeline cost %d >= %d after this PR; next call will be skipped",
+                cumulative_cost[0], TIMELINE_CUMULATIVE_WARN,
+            )
 
-        if cumulative_cost is not None:
-            cost = accumulated_cost[0]
-            remaining = last_remaining[0]
-            if cost > TIMELINE_COST_WARN:
-                print(
-                    f"WARNING: timeline query cost {cost} exceeds threshold {TIMELINE_COST_WARN}",
-                    file=sys.stderr,
-                )
-            if remaining < 100:
-                print(
-                    f"CRITICAL: rateLimit.remaining={remaining} — approaching rate limit",
-                    file=sys.stderr,
-                )
+        if accumulated_cost[0] > TIMELINE_COST_WARN:
+            logger.warning(
+                "Timeline query cost %d exceeds per-PR threshold %d",
+                accumulated_cost[0], TIMELINE_COST_WARN,
+            )
 
         return nodes
 

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -418,15 +418,26 @@ class GraphQLClient:
             if remaining is not None:
                 last_remaining[0] = remaining
 
-        nodes = self.paginate(
-            query=PR_TIMELINE_QUERY,
-            variables={"prId": pr_node_id, "cursor": None},
-            page_info_path=["data", "node", "timelineItems", "pageInfo"],
-            nodes_path=["data", "node", "timelineItems", "nodes"],
-            deadline_monotonic=deadline_monotonic,
-            cursor_var="cursor",
-            on_page_response=_on_page,
-        )
+        # try/finally ensures cost is flushed even if paginate() raises mid-walk
+        try:
+            nodes = self.paginate(
+                query=PR_TIMELINE_QUERY,
+                variables={"prId": pr_node_id, "cursor": None},
+                page_info_path=["data", "node", "timelineItems", "pageInfo"],
+                nodes_path=["data", "node", "timelineItems", "nodes"],
+                deadline_monotonic=deadline_monotonic,
+                cursor_var="cursor",
+                on_page_response=_on_page,
+            )
+        finally:
+            # Always flush accumulated cost, even if paginate() raised
+            if cumulative_cost is not None:
+                cumulative_cost[0] += accumulated_cost[0]
+                if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+                    raise CostBudgetExceeded(
+                        f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
+                        "skipping remaining timeline fetches for this run"
+                    )
 
         if node_not_found[0]:
             raise PRNodeNotFound(f"PR node_id not found on GitHub: {pr_node_id}")
@@ -434,7 +445,6 @@ class GraphQLClient:
         if cumulative_cost is not None:
             cost = accumulated_cost[0]
             remaining = last_remaining[0]
-            cumulative_cost[0] += cost
             if cost > TIMELINE_COST_WARN:
                 print(
                     f"WARNING: timeline query cost {cost} exceeds threshold {TIMELINE_COST_WARN}",
@@ -444,11 +454,6 @@ class GraphQLClient:
                 print(
                     f"CRITICAL: rateLimit.remaining={remaining} — approaching rate limit",
                     file=sys.stderr,
-                )
-            if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
-                raise CostBudgetExceeded(
-                    f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
-                    "skipping remaining timeline fetches for this run"
                 )
 
         return nodes

--- a/pulse/migrate.py
+++ b/pulse/migrate.py
@@ -50,7 +50,7 @@ def run_migration(db_path: Path) -> str:
     4. Pre-migration integrity check
     5. Disk-space check (backup size × 2 ≤ free space, including WAL/SHM)
     6. Backup DB → pulse.db.pre-v1-<ISO-8601-microseconds>
-    7. ALTER TABLE — 3 new columns (upstream, vulnerability_alerts, review_events)
+    7. ALTER TABLE — 4 new columns (upstream, vulnerability_alerts, node_id, review_events)
     8. Post-migration integrity check
     9. PRAGMA user_version = 11
     10. Return "migrated"
@@ -118,12 +118,14 @@ def run_migration(db_path: Path) -> str:
         # Fix 3: IF NOT EXISTS guards for ALTER TABLE
         # SQLite ALTER TABLE autocommits — with conn: does NOT roll back DDL.
         # Check column existence first to make partial migration recovery safe.
-        # 3 new columns added: upstream, vulnerability_alerts, review_events.
+        # 4 new columns added: upstream, vulnerability_alerts, node_id, review_events.
         # schema_version already exists in v0 DDL (DEFAULT '1.0') — no ALTER needed.
         if not _column_exists(conn, "repos", "upstream"):
             conn.execute("ALTER TABLE repos ADD COLUMN upstream TEXT")
         if not _column_exists(conn, "repos", "vulnerability_alerts"):
             conn.execute("ALTER TABLE repos ADD COLUMN vulnerability_alerts TEXT")
+        if not _column_exists(conn, "prs", "node_id"):
+            conn.execute("ALTER TABLE prs ADD COLUMN node_id TEXT")
         if not _column_exists(conn, "prs", "review_events"):
             conn.execute("ALTER TABLE prs ADD COLUMN review_events TEXT")
 

--- a/pulse/schema.py
+++ b/pulse/schema.py
@@ -4,6 +4,16 @@ from dataclasses import dataclass, field
 
 
 @dataclass
+class ReviewEvent:
+    type: str  # __typename: PULL_REQUEST_REVIEW, REVIEW_REQUESTED_EVENT, MERGED_EVENT, CLOSED_EVENT, LABELED_EVENT, REFERENCED_EVENT
+    author: str | None
+    state: str | None = None      # for PULL_REQUEST_REVIEW: APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED
+    label: str | None = None      # for LABELED_EVENT
+    submitted_at: str | None = None
+    created_at: str | None = None
+
+
+@dataclass
 class FieldStatus:
     status: str  # success | partial | disabled | failed
     error_note: str | None = None
@@ -38,6 +48,7 @@ class PRData:
     is_renovate: bool
     hours_idle: float | None
     stalled: bool
+    node_id: str | None = None
     review_events: list | None = None
 
 

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -381,18 +381,33 @@ def _capture_pr_timelines(
                     error_note=f"timeline capture failed for PR #{pr.number}: {str(e)[:100]}",
                 )
 
-    if skipped_no_node_id == len(prs) and prs:
-        logging.getLogger(__name__).warning(
-            "All %d PRs for repo_id=%s lack node_id; timeline capture skipped entirely",
-            len(prs), repo_id,
-        )
+    if skipped_no_node_id > 0 and prs:
+        if skipped_no_node_id == len(prs):
+            logging.getLogger(__name__).warning(
+                "All %d PRs for repo_id=%s lack node_id; timeline capture skipped entirely",
+                len(prs), repo_id,
+            )
+        else:
+            logging.getLogger(__name__).warning(
+                "%d/%d PRs for repo_id=%s lack node_id; their timelines skipped",
+                skipped_no_node_id, len(prs), repo_id,
+            )
+        # Treat as partial — we skipped work we should have done
+        any_failure = True
 
     if budget_exceeded:
         repo.field_statuses["review_events"] = FieldStatus(
             status="partial",
             error_note=f"skipped: cumulative cost approached {TIMELINE_CUMULATIVE_WARN}/hr limit",
         )
-    elif not any_failure:
+    elif any_failure:
+        # Set partial if not already set by the per-PR exception handler above
+        if "review_events" not in repo.field_statuses:
+            repo.field_statuses["review_events"] = FieldStatus(
+                status="partial",
+                error_note=f"all {len(prs)} PRs lack node_id; timeline capture skipped",
+            )
+    else:
         repo.field_statuses["review_events"] = FieldStatus(status="success")
 
 

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -624,6 +624,7 @@ def _build_current_json(
                         "is_dependabot": bool(r["is_dependabot"]),
                         "is_renovate": bool(r["is_renovate"]),
                         "stalled": bool(r["stalled"]),
+                        "review_events": json.loads(r["review_events"]) if r["review_events"] else None,
                     }
                     for r in pr_rows
                 ],

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -405,7 +405,7 @@ def _capture_pr_timelines(
         if "review_events" not in repo.field_statuses:
             repo.field_statuses["review_events"] = FieldStatus(
                 status="partial",
-                error_note=f"all {len(prs)} PRs lack node_id; timeline capture skipped",
+                error_note=f"{skipped_no_node_id}/{len(prs)} PRs lack node_id; timeline capture skipped",
             )
     else:
         repo.field_statuses["review_events"] = FieldStatus(status="success")

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -9,8 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from pulse.config import PulseConfig
-from pulse.graphql import GraphQLClient
-from pulse.schema import FieldStatus, IssueData, PRData, ReleaseData, RepoData
+from pulse.graphql import CostBudgetExceeded, GraphQLClient, TIMELINE_CUMULATIVE_WARN
+from pulse.schema import FieldStatus, IssueData, PRData, ReleaseData, RepoData, ReviewEvent
 from pulse.storage import atomic_write_json
 
 DEPENDABOT_AUTHORS = {"dependabot[bot]", "dependabot-preview[bot]", "app/dependabot"}
@@ -48,6 +48,7 @@ query($org: String!, $repo: String!, $first: Int!, $cursor: String) {
       totalCount
       pageInfo { hasNextPage endCursor }
       nodes {
+        id
         number title
         author { login }
         createdAt updatedAt
@@ -160,6 +161,7 @@ def _capture_prs(
                     is_renovate=author_login in RENOVATE_AUTHORS if author_login else False,
                     hours_idle=idle,
                     stalled=idle is not None and idle > stall_hours,
+                    node_id=node.get("id"),
                 )
             )
 
@@ -280,6 +282,107 @@ def _capture_releases(
 
 
 
+def _event_to_review_event(node: dict) -> ReviewEvent:
+    """Convert a raw timeline event node to a ReviewEvent."""
+    typename = node.get("__typename", "")
+    actor = (node.get("actor") or {}).get("login") or None
+    author_obj = (node.get("author") or {}).get("login") or None
+    # PullRequestReview uses 'author', all others use 'actor'
+    author = author_obj if typename == "PullRequestReview" else actor
+    label_obj = node.get("label") or {}
+    return ReviewEvent(
+        type=typename,
+        author=author,
+        state=node.get("state") if typename == "PullRequestReview" else None,
+        label=label_obj.get("name") if typename == "LabeledEvent" else None,
+        submitted_at=node.get("submittedAt") if typename == "PullRequestReview" else None,
+        created_at=node.get("createdAt") if typename != "PullRequestReview" else None,
+    )
+
+
+def _capture_pr_timelines(
+    gql: GraphQLClient,
+    conn: sqlite3.Connection,
+    repo_id: int,
+    prs: list[PRData],
+    repo: RepoData,
+    deadline: float | None,
+    cumulative_cost: list[int],
+) -> None:
+    """Fetch timeline events for each PR and write review_events JSON to the prs table.
+
+    Graceful degradation: per-PR failures set review_events=NULL and update
+    repo.field_statuses['review_events'] to partial. CostBudgetExceeded causes
+    remaining PRs to be skipped (review_events stays NULL).
+    """
+    budget_exceeded = False
+    any_failure = False
+
+    for pr in prs:
+        if budget_exceeded:
+            # Skip remaining — leave review_events NULL
+            continue
+
+        if not pr.node_id:
+            # No node_id available — skip silently
+            continue
+
+        try:
+            raw_events = gql.fetch_pr_timeline(
+                pr.node_id,
+                deadline_monotonic=deadline,
+                cumulative_cost=cumulative_cost,
+            )
+            events = [_event_to_review_event(n) for n in raw_events if n.get("__typename")]
+            review_json = json.dumps(
+                [
+                    {
+                        "type": e.type,
+                        "author": e.author,
+                        "state": e.state,
+                        "label": e.label,
+                        "submitted_at": e.submitted_at,
+                        "created_at": e.created_at,
+                    }
+                    for e in events
+                ]
+            )
+            with conn:
+                conn.execute(
+                    "UPDATE prs SET review_events=? WHERE repo_id=? AND number=?",
+                    (review_json, repo_id, pr.number),
+                )
+
+        except CostBudgetExceeded as e:
+            import sys as _sys
+            print(f"WARNING: {e} — skipping remaining PR timelines", file=_sys.stderr)
+            budget_exceeded = True
+            any_failure = True
+
+        except Exception as e:
+            import sys as _sys
+            print(
+                f"WARNING: timeline capture failed for PR #{pr.number}: {e}",
+                file=_sys.stderr,
+            )
+            any_failure = True
+            # Leave review_events=NULL for this PR
+            existing = repo.field_statuses.get("review_events")
+            if existing is None or existing.status == "success":
+                repo.field_statuses["review_events"] = FieldStatus(
+                    status="partial",
+                    error_note=f"timeline capture failed for PR #{pr.number}: {str(e)[:100]}",
+                )
+
+    if budget_exceeded:
+        repo.field_statuses["review_events"] = FieldStatus(
+            status="partial",
+            error_note=f"skipped: cumulative cost approached {TIMELINE_CUMULATIVE_WARN}/hr limit",
+        )
+    elif not any_failure:
+        repo.field_statuses["review_events"] = FieldStatus(status="success")
+
+
 def _insert_snapshot_placeholder(
     db_conn: sqlite3.Connection,
     snapshot_id: str,
@@ -333,7 +436,7 @@ def _persist_repo(
     prs: list[PRData],
     issues: list[IssueData],
     releases: list[ReleaseData],
-) -> None:
+) -> int:
     field_statuses_json = json.dumps(
         {k: {"status": v.status, "error_note": v.error_note} for k, v in repo.field_statuses.items()}
     )
@@ -366,8 +469,9 @@ def _persist_repo(
                 """
                 INSERT OR REPLACE INTO prs
                   (repo_id, number, title, author, created_at, updated_at,
-                   is_draft, is_dependabot, is_renovate, hours_idle, stalled)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   is_draft, is_dependabot, is_renovate, hours_idle, stalled,
+                   node_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     repo_id,
@@ -381,6 +485,7 @@ def _persist_repo(
                     int(pr.is_renovate),
                     pr.hours_idle,
                     int(pr.stalled),
+                    pr.node_id,
                 ),
             )
 
@@ -421,6 +526,7 @@ def _persist_repo(
                 ),
             )
 
+    return repo_id
 
 
 def _prune_old_snapshots(
@@ -552,6 +658,8 @@ def run_snapshot(
 
     org_errors: list[str] = []
     orgs_succeeded = 0
+    # Cumulative rateLimit.cost tracker across all timeline queries in this run
+    cumulative_timeline_cost: list[int] = [0]
     for org_name, org_config in cfg.orgs.items():
         # Enumerate repos
         try:
@@ -652,7 +760,7 @@ def run_snapshot(
 
             # Persist to SQLite
             try:
-                _persist_repo(db_conn, snapshot_id, repo, prs, issues, releases)
+                repo_id = _persist_repo(db_conn, snapshot_id, repo, prs, issues, releases)
             except Exception as e:
                 click.echo(f"ERROR: failed to persist {org_name}/{repo_name}: {e}", err=True)
                 repos_failed += 1
@@ -660,6 +768,36 @@ def run_snapshot(
                     repos_partial -= 1
                 else:
                     repos_succeeded -= 1
+                continue
+
+            # Capture PR timelines (after persist so we have repo_id)
+            if repo_id is not None and prs:
+                _capture_pr_timelines(
+                    gql, db_conn, repo_id, prs, repo,
+                    deadline, cumulative_timeline_cost,
+                )
+                # Re-evaluate repo status after timeline capture
+                if "review_events" in repo.field_statuses:
+                    rev_status = repo.field_statuses["review_events"]
+                    if rev_status.status in ("partial", "failed"):
+                        if counted_as == "success":
+                            repos_succeeded -= 1
+                            repos_partial += 1
+                            repo.capture_status = "partial"
+                            counted_as = "partial"
+                # Update field_statuses in the DB row
+                try:
+                    field_statuses_json = json.dumps(
+                        {k: {"status": v.status, "error_note": v.error_note}
+                         for k, v in repo.field_statuses.items()}
+                    )
+                    with db_conn:
+                        db_conn.execute(
+                            "UPDATE repos SET field_statuses=?, capture_status=? WHERE id=?",
+                            (field_statuses_json, repo.capture_status, repo_id),
+                        )
+                except Exception as e:
+                    click.echo(f"WARNING: failed to update field_statuses for {org_name}/{repo_name}: {e}", err=True)
 
     duration_ms = int((time.monotonic() - start_time) * 1000)
 

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import time
 
@@ -9,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from pulse.config import PulseConfig
-from pulse.graphql import CostBudgetExceeded, GraphQLClient, TIMELINE_CUMULATIVE_WARN
+from pulse.graphql import CostBudgetExceeded, GraphQLClient, PRNodeNotFound, TIMELINE_CUMULATIVE_WARN
 from pulse.schema import FieldStatus, IssueData, PRData, ReleaseData, RepoData, ReviewEvent
 from pulse.storage import atomic_write_json
 
@@ -317,6 +318,7 @@ def _capture_pr_timelines(
     """
     budget_exceeded = False
     any_failure = False
+    skipped_no_node_id = 0
 
     for pr in prs:
         if budget_exceeded:
@@ -325,6 +327,7 @@ def _capture_pr_timelines(
 
         if not pr.node_id:
             # No node_id available — skip silently
+            skipped_no_node_id += 1
             continue
 
         try:
@@ -353,6 +356,10 @@ def _capture_pr_timelines(
                     (review_json, repo_id, pr.number),
                 )
 
+        except PRNodeNotFound:
+            # Node not found on GitHub — leave review_events NULL silently (not a failure)
+            pass
+
         except CostBudgetExceeded as e:
             import sys as _sys
             print(f"WARNING: {e} — skipping remaining PR timelines", file=_sys.stderr)
@@ -373,6 +380,12 @@ def _capture_pr_timelines(
                     status="partial",
                     error_note=f"timeline capture failed for PR #{pr.number}: {str(e)[:100]}",
                 )
+
+    if skipped_no_node_id == len(prs) and prs:
+        logging.getLogger(__name__).warning(
+            "All %d PRs for repo_id=%s lack node_id; timeline capture skipped entirely",
+            len(prs), repo_id,
+        )
 
     if budget_exceeded:
         repo.field_statuses["review_events"] = FieldStatus(

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -97,7 +97,13 @@ def open_db(path: Path) -> sqlite3.Connection:
             if any(k in msg for k in ("malformed", "corrupt", "not a database", "disk image")):
                 raise DBCorrupt(f"integrity_check raised exception (corrupt db): {e}") from e
             raise DBSetupError(f"integrity_check failed (env error): {e}") from e
+        tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        fresh = not tables
         create_schema(conn)
+        if fresh:
+            conn.execute("PRAGMA user_version = 11")  # fresh v1 install
         return conn
     except DBCorrupt:
         conn.close()
@@ -215,13 +221,6 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 -- repo is TEXT (not FK) so pagination state survives snapshot deletion/pruning
             )
         """)
-    # Set user_version=11 to mark this as a v1 schema on fresh installs, but only on a
-    # fresh DB (current_version=0). Prevents downgrading an already-migrated DB.
-    # Fresh installs include all v1 columns, so stamping 11 avoids a no-op migration run.
-    # Must run OUTSIDE the transaction (DDL auto-commits in SQLite).
-    current_version = conn.execute("PRAGMA user_version").fetchone()[0]
-    if current_version == 0:
-        conn.execute("PRAGMA user_version = 11")
 
 
 def atomic_write_json(path: Path, data: dict) -> None:

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -215,12 +215,13 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 -- repo is TEXT (not FK) so pagination state survives snapshot deletion/pruning
             )
         """)
-    # Set user_version=10 to mark this as a known v0 schema, but only on a
+    # Set user_version=11 to mark this as a v1 schema on fresh installs, but only on a
     # fresh DB (current_version=0). Prevents downgrading an already-migrated DB.
+    # Fresh installs include all v1 columns, so stamping 11 avoids a no-op migration run.
     # Must run OUTSIDE the transaction (DDL auto-commits in SQLite).
     current_version = conn.execute("PRAGMA user_version").fetchone()[0]
     if current_version == 0:
-        conn.execute("PRAGMA user_version = 10")
+        conn.execute("PRAGMA user_version = 11")
 
 
 def atomic_write_json(path: Path, data: dict) -> None:

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -160,6 +160,8 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 is_renovate INTEGER NOT NULL DEFAULT 0,
                 hours_idle REAL,
                 stalled INTEGER NOT NULL DEFAULT 0,
+                node_id TEXT,
+                review_events TEXT,
                 UNIQUE(repo_id, number)
             )
         """)

--- a/tests/test_graphql_timeline.py
+++ b/tests/test_graphql_timeline.py
@@ -1,0 +1,460 @@
+"""tests/test_graphql_timeline.py — PR timeline collection tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from pulse.graphql import (
+    CostBudgetExceeded,
+    GraphQLClient,
+    PR_TIMELINE_QUERY,
+    TIMELINE_CUMULATIVE_WARN,
+)
+from pulse.schema import PRData, ReviewEvent
+from pulse.snapshot import _capture_pr_timelines, _event_to_review_event
+from pulse.storage import create_schema
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_response(status_code: int, body: dict, headers: dict | None = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = body
+    resp.text = str(body)
+    resp.headers = headers or {}
+    return resp
+
+
+def _make_client(force_ipv4: bool = False) -> GraphQLClient:
+    with patch("pulse.graphql.apply_ipv4_patch"):
+        return GraphQLClient(token="test-token", force_ipv4=force_ipv4)
+
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    create_schema(conn)
+    return conn
+
+
+def _insert_repo_and_pr(
+    conn: sqlite3.Connection,
+    pr_number: int = 1,
+    node_id: str = "PR_abc123",
+    repo_id: int | None = None,
+) -> tuple[int, int]:
+    """Insert snapshot+repo (idempotent) and a PR row. Returns (repo_id, pr_rowid).
+
+    Pass repo_id to reuse an existing repo row instead of inserting a new one.
+    """
+    with conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO snapshots (id, captured_at_utc, captured_at_et, orgs_queried)"
+            " VALUES ('snap1', '2026-01-01T00:00:00Z', '2026-01-01 00:00 ET', '[]')"
+        )
+        if repo_id is None:
+            cur = conn.execute(
+                "INSERT INTO repos (snapshot_id, org, name, capture_status)"
+                " VALUES ('snap1', 'org', 'repo', 'success')"
+            )
+            repo_id = cur.lastrowid
+        cur2 = conn.execute(
+            "INSERT INTO prs (repo_id, number, title, stalled, node_id)"
+            " VALUES (?, ?, 'PR title', 0, ?)",
+            (repo_id, pr_number, node_id),
+        )
+    return repo_id, cur2.lastrowid
+
+
+def _timeline_body(
+    nodes: list[dict],
+    has_next_page: bool = False,
+    end_cursor: str | None = None,
+    cost: int = 1,
+    remaining: int = 4999,
+) -> dict:
+    return {
+        "data": {
+            "node": {
+                "timelineItems": {
+                    "totalCount": len(nodes),
+                    "pageInfo": {"hasNextPage": has_next_page, "endCursor": end_cursor},
+                    "nodes": nodes,
+                }
+            },
+            "rateLimit": {"cost": cost, "remaining": remaining},
+        }
+    }
+
+
+def _ratelimit_probe_body(cost: int = 1, remaining: int = 4999) -> dict:
+    return {"data": {"rateLimit": {"cost": cost, "remaining": remaining}}}
+
+
+def _sample_review_node() -> dict:
+    return {
+        "__typename": "PullRequestReview",
+        "author": {"login": "alice"},
+        "state": "APPROVED",
+        "submittedAt": "2026-01-02T10:00:00Z",
+    }
+
+
+def _sample_requested_node() -> dict:
+    return {
+        "__typename": "ReviewRequestedEvent",
+        "actor": {"login": "bob"},
+        "createdAt": "2026-01-02T09:00:00Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Single-page timeline (≤100 events), captured in one query
+# ---------------------------------------------------------------------------
+
+def test_single_page_timeline() -> None:
+    """Single page (2 events) — captured in one fetch_pr_timeline call."""
+    nodes = [_sample_review_node(), _sample_requested_node()]
+    timeline_resp = _make_response(200, _timeline_body(nodes))
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+
+    client = _make_client()
+    cumulative = [0]
+
+    with patch.object(client._client, "send", side_effect=[timeline_resp, probe_resp]):
+        result = client.fetch_pr_timeline("PR_abc", cumulative_cost=cumulative)
+
+    assert len(result) == 2
+    assert result[0]["__typename"] == "PullRequestReview"
+    assert result[1]["__typename"] == "ReviewRequestedEvent"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Multi-page timeline (>100 events) — pagination followed, events concatenated
+# ---------------------------------------------------------------------------
+
+def test_multi_page_timeline_concatenated() -> None:
+    """Timeline spanning 2 pages — both pages fetched, all events returned."""
+    page1_node = _sample_review_node()
+    page2_node = _sample_requested_node()
+
+    page1_resp = _make_response(200, _timeline_body(
+        [page1_node], has_next_page=True, end_cursor="cursor-p1"
+    ))
+    page2_resp = _make_response(200, _timeline_body(
+        [page2_node], has_next_page=False
+    ))
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+
+    client = _make_client()
+    call_count = 0
+
+    def fake_send(request: httpx.Request, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return page1_resp
+        elif call_count == 2:
+            return page2_resp
+        else:
+            return probe_resp
+
+    with patch.object(client._client, "send", side_effect=fake_send):
+        result = client.fetch_pr_timeline("PR_abc", cumulative_cost=[0])
+
+    assert len(result) == 2
+    assert result[0]["__typename"] == "PullRequestReview"
+    assert result[1]["__typename"] == "ReviewRequestedEvent"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: itemTypes filter — lower cost when filter present
+# ---------------------------------------------------------------------------
+
+def test_itemtypes_filter_reduces_cost() -> None:
+    """Filtered query returns lower cost than hypothetical unfiltered response."""
+    # Simulated: filtered = cost 1, unfiltered = cost 10 (we assert filtered < unfiltered)
+    filtered_cost = 1
+    unfiltered_cost = 10
+
+    filtered_body = _timeline_body([_sample_review_node()], cost=filtered_cost)
+    unfiltered_body = _timeline_body(
+        [_sample_review_node()] * 10, cost=unfiltered_cost
+    )
+
+    filtered_resp = _make_response(200, filtered_body)
+    probe_resp = _make_response(200, _ratelimit_probe_body(cost=filtered_cost))
+
+    client = _make_client()
+
+    with patch.object(client._client, "send", side_effect=[filtered_resp, probe_resp]):
+        client.fetch_pr_timeline("PR_abc", cumulative_cost=[0])
+
+    # Verify PR_TIMELINE_QUERY contains itemTypes filter
+    assert "itemTypes" in PR_TIMELINE_QUERY
+    assert "PULL_REQUEST_REVIEW" in PR_TIMELINE_QUERY
+    assert "MERGED_EVENT" in PR_TIMELINE_QUERY
+
+    # Assert cost advantage: filtered < unfiltered
+    assert filtered_cost < unfiltered_cost
+
+
+# ---------------------------------------------------------------------------
+# Test 4: JSON blob queryable via json_extract in SQLite
+# ---------------------------------------------------------------------------
+
+def test_review_events_json_queryable_in_sqlite() -> None:
+    """review_events written as JSON blob is queryable via json_extract."""
+    conn = _make_db()
+    repo_id, _ = _insert_repo_and_pr(conn, pr_number=1, node_id="PR_node1")
+
+    events = [
+        {"type": "PullRequestReview", "author": "alice", "state": "APPROVED",
+         "label": None, "submitted_at": "2026-01-02T10:00:00Z", "created_at": None},
+        {"type": "ReviewRequestedEvent", "author": "bob", "state": None,
+         "label": None, "submitted_at": None, "created_at": "2026-01-02T09:00:00Z"},
+    ]
+    review_json = json.dumps(events)
+    with conn:
+        conn.execute(
+            "UPDATE prs SET review_events=? WHERE repo_id=? AND number=1",
+            (review_json, repo_id),
+        )
+
+    row = conn.execute(
+        "SELECT json_extract(review_events, '$[0].type') AS first_type FROM prs WHERE repo_id=?",
+        (repo_id,),
+    ).fetchone()
+    assert row is not None
+    assert row["first_type"] == "PullRequestReview"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Pagination resume — cursor correctly resumes mid-walk
+# ---------------------------------------------------------------------------
+
+def test_pagination_resume_with_cursor() -> None:
+    """Second call with a cursor starts from where first left off."""
+    page2_node = {"__typename": "MergedEvent", "actor": {"login": "carol"}, "createdAt": "2026-01-03T00:00:00Z"}
+
+    # Only one page from cursor position
+    page2_resp = _make_response(200, _timeline_body([page2_node], has_next_page=False))
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+
+    client = _make_client()
+    captured_vars: list[dict] = []
+
+    def fake_send(request: httpx.Request, **kwargs):
+        import json as _json
+        body = _json.loads(request.content)
+        captured_vars.append(body.get("variables", {}))
+        if len(captured_vars) == 1:
+            return page2_resp
+        return probe_resp
+
+    with patch.object(client._client, "send", side_effect=fake_send):
+        result = client.fetch_pr_timeline("PR_abc", cumulative_cost=[0])
+
+    assert len(result) == 1
+    assert result[0]["__typename"] == "MergedEvent"
+    # The first call should have used prId=PR_abc
+    assert captured_vars[0].get("prId") == "PR_abc"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Partial-capture failure — one PR fails, others still captured
+# ---------------------------------------------------------------------------
+
+def test_partial_capture_failure_continues() -> None:
+    """One PR timeline failure sets its review_events=NULL; other PRs still captured."""
+    conn = _make_db()
+    repo_id, _ = _insert_repo_and_pr(conn, pr_number=1, node_id="PR_fail")
+    _insert_repo_and_pr(conn, pr_number=2, node_id="PR_ok", repo_id=repo_id)
+
+    prs = [
+        PRData(number=1, title="PR 1", author="a", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id="PR_fail"),
+        PRData(number=2, title="PR 2", author="b", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id="PR_ok"),
+    ]
+
+    ok_events = [_sample_review_node()]
+    ok_body = _timeline_body(ok_events)
+    ok_resp = _make_response(200, ok_body)
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+
+    client = _make_client()
+    call_count = 0
+
+    def fake_send(request: httpx.Request, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        import json as _json
+        body = _json.loads(request.content)
+        variables = body.get("variables", {})
+        pr_id = variables.get("prId", "")
+        if pr_id == "PR_fail":
+            raise httpx.NetworkError("simulated failure")
+        return ok_resp if "prId" in variables else probe_resp
+
+    from pulse.schema import FieldStatus, RepoData
+    repo = RepoData(org="o", name="r", default_branch="main", is_fork=False,
+                    is_archived=False, has_issues_enabled=True, parent_owner=None,
+                    parent_name=None, parent_is_deleted=False, capture_status="success")
+
+    with patch.object(client._client, "send", side_effect=fake_send), \
+         patch("pulse.graphql.time.sleep"):
+        _capture_pr_timelines(client, conn, repo_id, prs, repo, None, [0])
+
+    pr1 = conn.execute("SELECT review_events FROM prs WHERE repo_id=? AND number=1", (repo_id,)).fetchone()
+    pr2 = conn.execute("SELECT review_events FROM prs WHERE repo_id=? AND number=2", (repo_id,)).fetchone()
+
+    # PR 1 failed — review_events should be NULL
+    assert pr1["review_events"] is None
+    # PR 2 succeeded — should have JSON
+    assert pr2["review_events"] is not None
+    parsed = json.loads(pr2["review_events"])
+    assert isinstance(parsed, list)
+    assert len(parsed) > 0
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Empty timeline — PR with 0 events → review_events = '[]', not NULL
+# ---------------------------------------------------------------------------
+
+def test_empty_timeline_stores_empty_list() -> None:
+    """PR with 0 timeline events → review_events = '[]', not NULL."""
+    conn = _make_db()
+    repo_id, _ = _insert_repo_and_pr(conn, pr_number=1, node_id="PR_empty")
+
+    prs = [
+        PRData(number=1, title="PR 1", author="a", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id="PR_empty"),
+    ]
+
+    empty_body = _timeline_body([])
+    empty_resp = _make_response(200, empty_body)
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+
+    client = _make_client()
+    call_count = 0
+
+    def fake_send(request: httpx.Request, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return empty_resp if call_count == 1 else probe_resp
+
+    from pulse.schema import RepoData
+    repo = RepoData(org="o", name="r", default_branch="main", is_fork=False,
+                    is_archived=False, has_issues_enabled=True, parent_owner=None,
+                    parent_name=None, parent_is_deleted=False, capture_status="success")
+
+    with patch.object(client._client, "send", side_effect=fake_send):
+        _capture_pr_timelines(client, conn, repo_id, prs, repo, None, [0])
+
+    pr = conn.execute("SELECT review_events FROM prs WHERE repo_id=? AND number=1", (repo_id,)).fetchone()
+    assert pr["review_events"] is not None
+    assert json.loads(pr["review_events"]) == []
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Orphan PR (node ID not found in GitHub) — graceful degradation, no crash
+# ---------------------------------------------------------------------------
+
+def test_orphan_pr_node_id_not_found() -> None:
+    """PR node ID returns None from GitHub (node not found) — graceful, no crash."""
+    conn = _make_db()
+    repo_id, _ = _insert_repo_and_pr(conn, pr_number=1, node_id="PR_orphan")
+
+    prs = [
+        PRData(number=1, title="Orphan PR", author="a", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id="PR_orphan"),
+    ]
+
+    # GitHub returns node=null when node ID is not found
+    orphan_body = {
+        "data": {
+            "node": None,
+            "rateLimit": {"cost": 1, "remaining": 4999},
+        }
+    }
+    orphan_resp = _make_response(200, orphan_body)
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+    call_count = 0
+
+    def fake_send(request: httpx.Request, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return orphan_resp if call_count == 1 else probe_resp
+
+    client = _make_client()
+
+    from pulse.schema import RepoData
+    repo = RepoData(org="o", name="r", default_branch="main", is_fork=False,
+                    is_archived=False, has_issues_enabled=True, parent_owner=None,
+                    parent_name=None, parent_is_deleted=False, capture_status="success")
+
+    # Must not crash
+    with patch.object(client._client, "send", side_effect=fake_send):
+        _capture_pr_timelines(client, conn, repo_id, prs, repo, None, [0])
+
+    pr = conn.execute("SELECT review_events FROM prs WHERE repo_id=? AND number=1", (repo_id,)).fetchone()
+    # Node not found → path traversal returns [] → stored as '[]'
+    assert pr is not None
+    # Either empty list (graceful) or NULL (failure path) — either is acceptable, no crash
+    if pr["review_events"] is not None:
+        parsed = json.loads(pr["review_events"])
+        assert isinstance(parsed, list)
+
+
+# ---------------------------------------------------------------------------
+# Test 9 (bonus): _event_to_review_event correctly maps all typename fields
+# ---------------------------------------------------------------------------
+
+def test_event_to_review_event_mapping() -> None:
+    """_event_to_review_event correctly extracts fields for each __typename."""
+    review = _event_to_review_event({
+        "__typename": "PullRequestReview",
+        "author": {"login": "alice"},
+        "state": "APPROVED",
+        "submittedAt": "2026-01-02T10:00:00Z",
+    })
+    assert review.type == "PullRequestReview"
+    assert review.author == "alice"
+    assert review.state == "APPROVED"
+    assert review.submitted_at == "2026-01-02T10:00:00Z"
+    assert review.created_at is None
+
+    labeled = _event_to_review_event({
+        "__typename": "LabeledEvent",
+        "actor": {"login": "bot"},
+        "createdAt": "2026-01-02T11:00:00Z",
+        "label": {"name": "bug"},
+    })
+    assert labeled.type == "LabeledEvent"
+    assert labeled.author == "bot"
+    assert labeled.label == "bug"
+    assert labeled.state is None
+    assert labeled.submitted_at is None
+    assert labeled.created_at == "2026-01-02T11:00:00Z"
+
+    merged = _event_to_review_event({
+        "__typename": "MergedEvent",
+        "actor": {"login": "carol"},
+        "createdAt": "2026-01-03T00:00:00Z",
+    })
+    assert merged.type == "MergedEvent"
+    assert merged.label is None

--- a/tests/test_graphql_timeline.py
+++ b/tests/test_graphql_timeline.py
@@ -456,3 +456,55 @@ def test_event_to_review_event_mapping() -> None:
     })
     assert merged.type == "MergedEvent"
     assert merged.label is None
+
+
+# ---------------------------------------------------------------------------
+# Test 10: Pre-fetch gate — CostBudgetExceeded raised before any HTTP call
+# ---------------------------------------------------------------------------
+
+def test_pre_fetch_gate_skips_without_http_call() -> None:
+    """Budget already exhausted: fetch_pr_timeline raises before making any HTTP request."""
+    client = _make_client()
+    from unittest.mock import patch
+    with patch.object(client._client, "send") as mock_send:
+        with pytest.raises(CostBudgetExceeded):
+            client.fetch_pr_timeline("PR_abc123", cumulative_cost=[TIMELINE_CUMULATIVE_WARN])
+    mock_send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 11: All PRs missing node_id → review_events field_status = "partial"
+# ---------------------------------------------------------------------------
+
+def test_all_prs_missing_node_id_sets_partial_status() -> None:
+    """When every PR in a repo lacks node_id, review_events status should be 'partial'."""
+    from pulse.schema import FieldStatus, RepoData
+
+    conn = _make_db()
+    repo_id, _ = _insert_repo_and_pr(conn, pr_number=1, node_id=None)
+    _insert_repo_and_pr(conn, pr_number=2, node_id=None, repo_id=repo_id)
+
+    prs = [
+        PRData(number=1, title="PR 1", author="a", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id=None),
+        PRData(number=2, title="PR 2", author="b", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id=None),
+    ]
+
+    client = _make_client()
+    repo = RepoData(
+        org="o", name="r", default_branch="main", is_fork=False,
+        is_archived=False, has_issues_enabled=True, parent_owner=None,
+        parent_name=None, parent_is_deleted=False, capture_status="success",
+    )
+
+    # No HTTP calls should be made — all PRs skipped due to missing node_id
+    with patch.object(client._client, "send") as mock_send:
+        _capture_pr_timelines(client, conn, repo_id, prs, repo, None, [0])
+    mock_send.assert_not_called()
+
+    assert "review_events" in repo.field_statuses
+    assert repo.field_statuses["review_events"].status == "partial"
+    assert "2/2" in (repo.field_statuses["review_events"].error_note or "")

--- a/tests/test_graphql_timeline.py
+++ b/tests/test_graphql_timeline.py
@@ -306,7 +306,8 @@ def test_partial_capture_failure_continues() -> None:
         pr_id = variables.get("prId", "")
         if pr_id == "PR_fail":
             raise httpx.NetworkError("simulated failure")
-        return ok_resp if "prId" in variables else probe_resp
+        # With real-cost tracking via on_page_response, no separate probe call is made
+        return ok_resp
 
     from pulse.schema import FieldStatus, RepoData
     repo = RepoData(org="o", name="r", default_branch="main", is_fork=False,
@@ -412,12 +413,9 @@ def test_orphan_pr_node_id_not_found() -> None:
         _capture_pr_timelines(client, conn, repo_id, prs, repo, None, [0])
 
     pr = conn.execute("SELECT review_events FROM prs WHERE repo_id=? AND number=1", (repo_id,)).fetchone()
-    # Node not found → path traversal returns [] → stored as '[]'
     assert pr is not None
-    # Either empty list (graceful) or NULL (failure path) — either is acceptable, no crash
-    if pr["review_events"] is not None:
-        parsed = json.loads(pr["review_events"])
-        assert isinstance(parsed, list)
+    # Node not found → PRNodeNotFound raised → review_events stays NULL (not a failure)
+    assert pr["review_events"] is None, "Orphaned node_id should result in NULL review_events"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -16,14 +16,17 @@ from pulse.storage import create_schema
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 def _make_v0_db(path: Path) -> None:
-    """Create a v0 pulse DB at path.
+    """Create a v0 pulse DB at path (user_version=10).
 
-    create_schema() now sets user_version=10 internally, so no manual PRAGMA needed.
+    create_schema() stamps user_version=11 for fresh installs; we downgrade to 10
+    here to simulate a real v0 database that predates the v1 migration.
     """
     conn = sqlite3.connect(str(path))
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys=ON")
     create_schema(conn)
+    # Downgrade to v0 stamp so run_migration sees it as needing migration
+    conn.execute("PRAGMA user_version = 10")
     conn.close()
     path.chmod(0o600)
 


### PR DESCRIPTION
## Summary
- Adds `PR_TIMELINE_QUERY` to `graphql.py` with mandatory `itemTypes` filter
- Nested pagination via `node(id:)` for PRs with >100 timeline events (reuses/extends `paginate()`)
- Per-PR timeline collection in `snapshot.py` with graceful degradation on failure
- `ReviewEvent` model in `schema.py`
- Node-count guard: cumulative rateLimit.cost tracked; WARN + skip if approaching 4500/hr
- 9 tests in `tests/test_graphql_timeline.py`

Closes #47