### PR TITLE
feat(pulse): v1 fork upstream compare + vulnerability alerts (#48)

### DIFF
--- a/pulse/digest.py
+++ b/pulse/digest.py
@@ -114,7 +114,12 @@ def render_digest(db_conn: sqlite3.Connection, cfg: PulseConfig) -> str:
             status = fs_data.get("status", "success")
             error_note = fs_data.get("error_note") or ""
             error_note_escaped = md_escape(str(error_note))
-            if status == "failed":
+            if status == "scope_missing":
+                alert_lines.append(
+                    f"- 🔴 **SCOPE MISSING — {repo_label}**: {field_name} — token lacks required permissions. "
+                    f"Run `pulse --self-check` and ensure GH\\_TOKEN has `read:security\\_events` scope."
+                )
+            elif status == "failed":
                 alert_lines.append(f"- ❌ **{repo_label}**: {field_name} failed — {error_note_escaped}")
             elif status == "disabled":
                 alert_lines.append(f"- ⚠️ **{repo_label}**: {field_name} field disabled")

--- a/pulse/gh_rest.py
+++ b/pulse/gh_rest.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from pulse.ipv4 import apply_ipv4_patch
+
+logger = logging.getLogger(__name__)
+
+_RATELIMIT_WARN_THRESHOLD = 10
+
+
+class GHRestClient:
+    BASE_URL = "https://api.github.com"
+
+    def __init__(self, token: str, force_ipv4: bool = True) -> None:
+        if force_ipv4:
+            apply_ipv4_patch()
+        self._client = httpx.Client(
+            base_url=self.BASE_URL,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=30.0,
+        )
+
+    def _check_ratelimit_header(self, resp: httpx.Response) -> None:
+        try:
+            remaining = int(resp.headers.get("x-ratelimit-remaining", 100))
+        except (ValueError, TypeError):
+            return
+        if remaining < _RATELIMIT_WARN_THRESHOLD:
+            logger.warning(
+                "GitHub REST rate limit remaining=%d — approaching limit", remaining
+            )
+
+    def compare_fork_upstream(
+        self,
+        fork_owner: str,
+        fork_repo: str,
+        fork_default_branch: str,
+        parent_owner: str,
+        parent_default_branch: str,
+    ) -> dict:
+        """Compare fork to upstream using GitHub REST compare endpoint.
+
+        Returns upstream status dict for repos.upstream JSON blob.
+        NEVER hardcodes branch names — uses captured default_branch values.
+        """
+        url = (
+            f"/repos/{fork_owner}/{fork_repo}/compare"
+            f"/{parent_owner}:{parent_default_branch}...{fork_owner}:{fork_default_branch}"
+        )
+        resp = self._client.get(url)
+        self._check_ratelimit_header(resp)
+        if resp.status_code == 404:
+            return {"status": "parent_unavailable", "error_note": resp.text[:200]}
+        resp.raise_for_status()
+        data = resp.json()
+        return {
+            "status": "success",
+            "commits_behind": data.get("behind_by", 0),
+            "commits_ahead": data.get("ahead_by", 0),
+            "recent_upstream_releases": [],
+        }
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "GHRestClient":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/pulse/gh_rest.py
+++ b/pulse/gh_rest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from urllib.parse import quote
 
 import httpx
 
@@ -50,9 +51,11 @@ class GHRestClient:
         Returns upstream status dict for repos.upstream JSON blob.
         NEVER hardcodes branch names — uses captured default_branch values.
         """
+        encoded_fork_branch = quote(fork_default_branch, safe="")
+        encoded_parent_branch = quote(parent_default_branch, safe="")
         url = (
             f"/repos/{fork_owner}/{fork_repo}/compare"
-            f"/{parent_owner}:{parent_default_branch}...{fork_owner}:{fork_default_branch}"
+            f"/{parent_owner}:{encoded_parent_branch}...{fork_owner}:{encoded_fork_branch}"
         )
         resp = self._client.get(url)
         self._check_ratelimit_header(resp)

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -345,8 +345,8 @@ class GraphQLClient:
                 if on_page_response is not None:
                     try:
                         on_page_response(body)
-                    except PRNodeNotFound:
-                        raise  # null-node sentinel: stop pagination immediately
+                    except (PRNodeNotFound, ScopeMissing):
+                        raise  # sentinel exceptions: stop pagination immediately
                     except Exception:
                         pass  # other callback failures must not interrupt pagination
 
@@ -382,7 +382,7 @@ class GraphQLClient:
 
                 variables[cursor_var] = end_cursor
 
-        except (RunDeadlineExceeded, RetriesExhausted, CostBudgetExceeded, RuntimeError, PRNodeNotFound):
+        except (RunDeadlineExceeded, RetriesExhausted, CostBudgetExceeded, RuntimeError, PRNodeNotFound, ScopeMissing):
             # Interrupted — save cursor so next run resumes instead of restarting from page 1
             if use_checkpoint and last_cursor:
                 try:
@@ -544,10 +544,6 @@ class GraphQLClient:
             )
 
         accumulated_cost = [0]
-        # Mutable flag: on_page_response sets this when INSUFFICIENT_SCOPES detected.
-        # paginate() swallows all exceptions except PRNodeNotFound from on_page_response,
-        # so we signal via flag and raise after paginate() returns.
-        scope_missing_msg: list[str] = []
 
         def _on_page(resp: dict) -> None:
             data = resp.get("data") or {}
@@ -559,11 +555,11 @@ class GraphQLClient:
                 logger.warning(
                     "GitHub rate limit remaining=%d — approaching limit", remaining
                 )
-            # Check for INSUFFICIENT_SCOPES error (flag — not raise, paginate() swallows it)
+            # Raise ScopeMissing directly — paginate() re-raises it (same as PRNodeNotFound).
             errors = resp.get("errors") or []
             for err in errors:
                 if err.get("type") == "INSUFFICIENT_SCOPES":
-                    scope_missing_msg.append(
+                    raise ScopeMissing(
                         f"Token lacks required scope for vulnerabilityAlerts: {err.get('message', '')}"
                     )
 
@@ -582,10 +578,6 @@ class GraphQLClient:
         finally:
             if cumulative_cost is not None:
                 cumulative_cost[0] += accumulated_cost[0]
-
-        # Raise ScopeMissing after paginate() completes if flag was set
-        if scope_missing_msg:
-            raise ScopeMissing(scope_missing_msg[0])
 
         # Convert nodes to VulnerabilityAlert, dedup by (ghsa_id, package_name)
         seen: set[tuple[str, str]] = set()

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -6,6 +6,7 @@ import sqlite3
 import sys
 import time
 from collections.abc import Callable
+from datetime import datetime, timezone
 
 import httpx
 
@@ -21,6 +22,27 @@ DEFAULT_DEADLINE_SEC = int(os.environ.get("PULSE_RUN_DEADLINE_SEC", "1200"))
 TIMELINE_COST_WARN = 100
 # Cumulative budget guard: warn + skip remaining timeline fetches above this point
 TIMELINE_CUMULATIVE_WARN = 4500
+
+VULN_ALERTS_QUERY = """
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    vulnerabilityAlerts(first: 100, after: $cursor, states: OPEN) {
+      totalCount
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        securityVulnerability {
+          severity
+          package { name ecosystem }
+          advisory { ghsaId publishedAt }
+        }
+        dependabotUpdate { pullRequest { number updatedAt } }
+        createdAt
+      }
+    }
+  }
+  rateLimit { cost remaining }
+}
+"""
 
 PR_TIMELINE_QUERY = """
 query($prId: ID!, $cursor: String) {
@@ -73,6 +95,11 @@ class CostBudgetExceeded(Exception):
 
 class PRNodeNotFound(Exception):
     """Raised when a PR node_id is not found on GitHub (data.node=null)."""
+    pass
+
+
+class ScopeMissing(Exception):
+    """Raised when the GitHub token lacks required scopes (e.g. security_events)."""
     pass
 
 
@@ -473,4 +500,107 @@ class GraphQLClient:
             )
 
         return nodes
+
+    @staticmethod
+    def _node_to_vuln_alert(node: dict) -> "VulnerabilityAlert":
+        from pulse.schema import VulnerabilityAlert
+        vuln = node["securityVulnerability"]
+        published = vuln["advisory"]["publishedAt"]  # ISO-8601
+        age_days = (
+            datetime.now(timezone.utc)
+            - datetime.fromisoformat(published.replace("Z", "+00:00"))
+        ).days
+        dep_pr = None
+        if node.get("dependabotUpdate") and node["dependabotUpdate"].get("pullRequest"):
+            dep_pr = node["dependabotUpdate"]["pullRequest"]["number"]
+        return VulnerabilityAlert(
+            severity=vuln["severity"],
+            ghsa_id=vuln["advisory"]["ghsaId"],
+            package_name=vuln["package"]["name"],
+            ecosystem=vuln["package"]["ecosystem"],
+            age_days=age_days,
+            dependabot_pr_number=dep_pr,
+        )
+
+    def fetch_vuln_alerts(
+        self,
+        owner: str,
+        name: str,
+        cumulative_cost: list[int] | None = None,
+    ) -> list["VulnerabilityAlert"]:
+        """Fetch all open vulnerability alerts for a repo, paginating if needed.
+
+        Returns list of VulnerabilityAlert objects, deduped by (ghsa_id, package_name).
+        Raises ScopeMissing if token lacks security_events scope.
+        Raises CostBudgetExceeded if cumulative cost gate fires before first fetch.
+        """
+        from pulse.schema import VulnerabilityAlert
+
+        # Pre-fetch gate: skip if already over budget (same pattern as fetch_pr_timeline)
+        if cumulative_cost is not None and cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+            raise CostBudgetExceeded(
+                f"cumulative cost {cumulative_cost[0]} already >= {TIMELINE_CUMULATIVE_WARN}; "
+                "skipping vuln alerts fetch for this run"
+            )
+
+        accumulated_cost = [0]
+        # Mutable flag: on_page_response sets this when INSUFFICIENT_SCOPES detected.
+        # paginate() swallows all exceptions except PRNodeNotFound from on_page_response,
+        # so we signal via flag and raise after paginate() returns.
+        scope_missing_msg: list[str] = []
+
+        def _on_page(resp: dict) -> None:
+            data = resp.get("data") or {}
+            rate = data.get("rateLimit") or {}
+            page_cost = rate.get("cost", 0)
+            accumulated_cost[0] += page_cost
+            remaining = rate.get("remaining")
+            if remaining is not None and remaining < 100:
+                logger.warning(
+                    "GitHub rate limit remaining=%d — approaching limit", remaining
+                )
+            # Check for INSUFFICIENT_SCOPES error (flag — not raise, paginate() swallows it)
+            errors = resp.get("errors") or []
+            for err in errors:
+                if err.get("type") == "INSUFFICIENT_SCOPES":
+                    scope_missing_msg.append(
+                        f"Token lacks required scope for vulnerabilityAlerts: {err.get('message', '')}"
+                    )
+
+        try:
+            nodes = self.paginate(
+                query=VULN_ALERTS_QUERY,
+                variables={"owner": owner, "name": name, "cursor": None},
+                page_info_path=["data", "repository", "vulnerabilityAlerts", "pageInfo"],
+                nodes_path=["data", "repository", "vulnerabilityAlerts", "nodes"],
+                cursor_var="cursor",
+                on_page_response=_on_page,
+            )
+        except CostBudgetExceeded as e:
+            accumulated_cost[0] += getattr(e, "cost", 0)
+            raise
+        finally:
+            if cumulative_cost is not None:
+                cumulative_cost[0] += accumulated_cost[0]
+
+        # Raise ScopeMissing after paginate() completes if flag was set
+        if scope_missing_msg:
+            raise ScopeMissing(scope_missing_msg[0])
+
+        # Convert nodes to VulnerabilityAlert, dedup by (ghsa_id, package_name)
+        seen: set[tuple[str, str]] = set()
+        alerts: list[VulnerabilityAlert] = []
+        for node in nodes:
+            try:
+                alert = self._node_to_vuln_alert(node)
+            except (KeyError, TypeError) as e:
+                logger.warning("Failed to parse vuln alert node: %s", e)
+                continue
+            key = (alert.ghsa_id, alert.package_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            alerts.append(alert)
+
+        return alerts
 

--- a/pulse/schema.py
+++ b/pulse/schema.py
@@ -2,6 +2,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from pydantic import BaseModel
+
+
+class UpstreamStatus(BaseModel):
+    status: str  # "success" | "parent_unavailable" | "failed" | "not_fork"
+    commits_behind: int | None = None
+    commits_ahead: int | None = None
+    recent_upstream_releases: list[dict] | None = None
+    error_note: str | None = None
+
+
+class VulnerabilityAlert(BaseModel):
+    severity: str           # CRITICAL | HIGH | MODERATE | LOW (verbatim from GitHub)
+    ghsa_id: str
+    package_name: str
+    ecosystem: str
+    age_days: int
+    dependabot_pr_number: int | None = None
+
 
 @dataclass
 class ReviewEvent:
@@ -34,6 +53,7 @@ class RepoData:
     field_statuses: dict[str, FieldStatus] = field(default_factory=dict)
     upstream: dict | None = None
     vulnerability_alerts: list | None = None
+    parent_default_branch: str | None = None
 
 
 @dataclass

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -10,7 +10,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from pulse.config import PulseConfig
-from pulse.graphql import CostBudgetExceeded, GraphQLClient, PRNodeNotFound, TIMELINE_CUMULATIVE_WARN
+from pulse.gh_rest import GHRestClient
+from pulse.graphql import CostBudgetExceeded, GraphQLClient, PRNodeNotFound, ScopeMissing, TIMELINE_CUMULATIVE_WARN
 from pulse.schema import FieldStatus, IssueData, PRData, ReleaseData, RepoData, ReviewEvent
 from pulse.storage import atomic_write_json
 
@@ -34,7 +35,7 @@ query($org: String!, $cursor: String) {
         hasIssuesEnabled
         pullRequests(first: 1) { totalCount }
         issues(first: 1) { totalCount }
-        parent { owner { login } name }
+        parent { owner { login } name defaultBranchRef { name } }
       }
     }
   }
@@ -281,6 +282,115 @@ def _capture_releases(
     except Exception as e:
         return [], FieldStatus(status="failed", error_note=str(e)[:200])
 
+
+
+def _capture_upstream(
+    rest_client: GHRestClient,
+    repo: RepoData,
+    conn: sqlite3.Connection,
+    repo_id: int,
+) -> None:
+    """Capture fork upstream compare delta and store as JSON in repos.upstream.
+
+    Only runs if repo.is_fork == True and repo.parent is available.
+    Gracefully degrades: exceptions stored as failed status, never abort caller.
+    """
+    if not repo.is_fork:
+        return
+    if not repo.parent_owner or not repo.parent_name:
+        return
+
+    fork_branch = repo.default_branch
+    parent_branch = repo.parent_default_branch if hasattr(repo, "parent_default_branch") else None
+
+    if not fork_branch or not parent_branch:
+        upstream_blob = {
+            "status": "failed",
+            "error_note": "missing default_branch for fork or parent",
+        }
+        repo.field_statuses["upstream"] = FieldStatus(
+            status="failed", error_note=upstream_blob["error_note"]
+        )
+    else:
+        try:
+            result = rest_client.compare_fork_upstream(
+                fork_owner=repo.org,
+                fork_repo=repo.name,
+                fork_default_branch=fork_branch,
+                parent_owner=repo.parent_owner,
+                parent_default_branch=parent_branch,
+            )
+            upstream_blob = result
+            repo.field_statuses["upstream"] = FieldStatus(
+                status=result.get("status", "success")
+                if result.get("status") in ("success", "parent_unavailable")
+                else "failed"
+            )
+        except Exception as e:
+            upstream_blob = {"status": "failed", "error_note": str(e)[:200]}
+            repo.field_statuses["upstream"] = FieldStatus(
+                status="failed", error_note=str(e)[:200]
+            )
+
+    try:
+        with conn:
+            conn.execute(
+                "UPDATE repos SET upstream=? WHERE id=?",
+                (json.dumps(upstream_blob), repo_id),
+            )
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            "Failed to write upstream for repo_id=%s: %s", repo_id, e
+        )
+
+
+def _capture_vuln_alerts(
+    graphql_client: GraphQLClient,
+    repo: RepoData,
+    conn: sqlite3.Connection,
+    repo_id: int,
+    cumulative_cost: list[int] | None = None,
+) -> None:
+    """Capture open vulnerability alerts and store as JSON in repos.vulnerability_alerts.
+
+    Handles ScopeMissing with a LOUD field_status alert. Other exceptions stored as failed.
+    Gracefully degrades: never aborts caller.
+    """
+    alerts_blob: list | dict
+    try:
+        alerts = graphql_client.fetch_vuln_alerts(
+            owner=repo.org,
+            name=repo.name,
+            cumulative_cost=cumulative_cost,
+        )
+        alerts_blob = [a.model_dump() for a in alerts]
+        repo.field_statuses["vulnerability_alerts"] = FieldStatus(status="success")
+    except ScopeMissing as e:
+        alerts_blob = {"status": "scope_missing", "error_note": str(e)[:200]}
+        repo.field_statuses["vulnerability_alerts"] = FieldStatus(
+            status="scope_missing",
+            error_note=f"ALERT: token lacks security_events scope — vuln alerts unavailable: {str(e)[:150]}",
+        )
+        logging.getLogger(__name__).warning(
+            "SCOPE MISSING: vulnerability alerts require security_events scope on token (repo=%s/%s): %s",
+            repo.org, repo.name, e,
+        )
+    except Exception as e:
+        alerts_blob = {"status": "failed", "error_note": str(e)[:200]}
+        repo.field_statuses["vulnerability_alerts"] = FieldStatus(
+            status="failed", error_note=str(e)[:200]
+        )
+
+    try:
+        with conn:
+            conn.execute(
+                "UPDATE repos SET vulnerability_alerts=? WHERE id=?",
+                (json.dumps(alerts_blob), repo_id),
+            )
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            "Failed to write vulnerability_alerts for repo_id=%s: %s", repo_id, e
+        )
 
 
 def _event_to_review_event(node: dict) -> ReviewEvent:
@@ -652,6 +762,7 @@ def run_snapshot(
     gql: GraphQLClient,
     deadline: float | None,
     output_dir: Path | None = None,
+    rest_client: GHRestClient | None = None,
 ) -> str:
     """Run one full snapshot, persist to SQLite, write current/prev JSON. Returns snapshot_id."""
     start_time = time.monotonic()
@@ -684,6 +795,15 @@ def run_snapshot(
         captured_at_et=captured_at_et,
         orgs_queried=orgs_queried,
     )
+
+    # Set up REST client (caller may pass one in for testing; otherwise create from env)
+    _rest_client_owner = rest_client is None
+    if rest_client is None:
+        import os as _os
+        _token = _os.environ.get("GH_TOKEN") or _os.environ.get("GITHUB_TOKEN")
+        if _token:
+            rest_client = GHRestClient(token=_token)
+    _rest_client = rest_client
 
     org_errors: list[str] = []
     orgs_succeeded = 0
@@ -729,6 +849,7 @@ def run_snapshot(
             parent = node.get("parent") or {}
             parent_owner = (parent.get("owner") or {}).get("login")
             parent_name = parent.get("name")
+            parent_default_branch = (parent.get("defaultBranchRef") or {}).get("name")
 
             has_issues = bool(node.get("hasIssuesEnabled", True))
             default_branch_ref = node.get("defaultBranchRef") or {}
@@ -745,6 +866,7 @@ def run_snapshot(
                 parent_is_deleted=False,
                 capture_status="success",
                 field_statuses={},
+                parent_default_branch=parent_default_branch,
             )
 
             # Capture PRs
@@ -814,7 +936,31 @@ def run_snapshot(
                             repos_partial += 1
                             repo.capture_status = "partial"
                             counted_as = "partial"
-                # Update field_statuses in the DB row
+
+            # Capture fork upstream delta (REST, graceful)
+            if repo_id is not None and _rest_client is not None:
+                _capture_upstream(_rest_client, repo, db_conn, repo_id)
+                up_status = repo.field_statuses.get("upstream")
+                if up_status and up_status.status in ("partial", "failed"):
+                    if counted_as == "success":
+                        repos_succeeded -= 1
+                        repos_partial += 1
+                        repo.capture_status = "partial"
+                        counted_as = "partial"
+
+            # Capture vulnerability alerts (GraphQL, graceful)
+            if repo_id is not None:
+                _capture_vuln_alerts(gql, repo, db_conn, repo_id, cumulative_timeline_cost)
+                va_status = repo.field_statuses.get("vulnerability_alerts")
+                if va_status and va_status.status in ("partial", "failed", "scope_missing"):
+                    if counted_as == "success":
+                        repos_succeeded -= 1
+                        repos_partial += 1
+                        repo.capture_status = "partial"
+                        counted_as = "partial"
+
+            # Update field_statuses in the DB row after all captures
+            if repo_id is not None:
                 try:
                     field_statuses_json = json.dumps(
                         {k: {"status": v.status, "error_note": v.error_note}
@@ -863,5 +1009,12 @@ def run_snapshot(
 
     # Prune old snapshots
     _prune_old_snapshots(db_conn, cfg.defaults.history_days)
+
+    # Close REST client if we created it
+    if _rest_client_owner and _rest_client is not None:
+        try:
+            _rest_client.close()
+        except Exception:
+            pass
 
     return snapshot_id

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -301,7 +301,7 @@ def _capture_upstream(
         return
 
     fork_branch = repo.default_branch
-    parent_branch = repo.parent_default_branch if hasattr(repo, "parent_default_branch") else None
+    parent_branch = repo.parent_default_branch
 
     if not fork_branch or not parent_branch:
         upstream_blob = {
@@ -374,6 +374,11 @@ def _capture_vuln_alerts(
         logging.getLogger(__name__).warning(
             "SCOPE MISSING: vulnerability alerts require security_events scope on token (repo=%s/%s): %s",
             repo.org, repo.name, e,
+        )
+    except CostBudgetExceeded:
+        alerts_blob = {"status": "partial", "error_note": "skipped: cumulative cost budget reached"}
+        repo.field_statuses["vulnerability_alerts"] = FieldStatus(
+            status="partial", error_note="skipped: cumulative cost budget reached"
         )
     except Exception as e:
         alerts_blob = {"status": "failed", "error_note": str(e)[:200]}
@@ -727,6 +732,8 @@ def _build_current_json(
                 "parent_is_deleted": bool(repo_row["parent_is_deleted"]),
                 "capture_status": repo_row["capture_status"],
                 "field_statuses": json.loads(repo_row["field_statuses"] or "{}"),
+                "upstream": json.loads(repo_row["upstream"]) if repo_row["upstream"] else None,
+                "vulnerability_alerts": json.loads(repo_row["vulnerability_alerts"]) if repo_row["vulnerability_alerts"] else None,
                 "prs": [
                     {
                         **dict(r),

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -149,7 +149,9 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 parent_name TEXT,
                 parent_is_deleted INTEGER NOT NULL DEFAULT 0,
                 capture_status TEXT NOT NULL DEFAULT 'success',
-                field_statuses TEXT
+                field_statuses TEXT,
+                upstream TEXT,
+                vulnerability_alerts TEXT
             )
         """)
         conn.execute("""

--- a/tests/test_gh_rest.py
+++ b/tests/test_gh_rest.py
@@ -1,0 +1,188 @@
+"""tests/test_gh_rest.py — GHRestClient tests for fork upstream compare."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from pulse.gh_rest import GHRestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_rest_response(
+    status_code: int,
+    body: dict | None = None,
+    text: str = "",
+    headers: dict | None = None,
+) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = body or {}
+    resp.text = text or str(body or {})
+    resp.headers = headers or {}
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+def _make_client() -> GHRestClient:
+    with patch("pulse.gh_rest.apply_ipv4_patch"):
+        return GHRestClient(token="test-token", force_ipv4=False)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Happy path — fork compare returns commits_behind and commits_ahead
+# ---------------------------------------------------------------------------
+
+def test_compare_fork_upstream_happy_path() -> None:
+    """Happy path: compare endpoint returns behind_by and ahead_by correctly."""
+    compare_body = {
+        "status": "diverged",
+        "behind_by": 5,
+        "ahead_by": 2,
+        "commits": [],
+    }
+    resp = _make_rest_response(200, compare_body)
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        result = client.compare_fork_upstream(
+            fork_owner="myorg",
+            fork_repo="myfork",
+            fork_default_branch="develop",
+            parent_owner="upstream-org",
+            parent_default_branch="main",
+        )
+
+    assert result["status"] == "success"
+    assert result["commits_behind"] == 5
+    assert result["commits_ahead"] == 2
+    assert "recent_upstream_releases" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 2: 404 on deleted/missing upstream → parent_unavailable, no crash
+# ---------------------------------------------------------------------------
+
+def test_compare_fork_upstream_404_parent_unavailable() -> None:
+    """404 response → status=parent_unavailable, no exception raised."""
+    resp = _make_rest_response(
+        404, text="Not Found: upstream repo deleted"
+    )
+    # 404 should NOT trigger raise_for_status
+    resp.raise_for_status.side_effect = None
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        result = client.compare_fork_upstream(
+            fork_owner="myorg",
+            fork_repo="myfork",
+            fork_default_branch="main",
+            parent_owner="deleted-org",
+            parent_default_branch="main",
+        )
+
+    assert result["status"] == "parent_unavailable"
+    assert "error_note" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Branch names from captured data appear in the request URL — not hardcoded "main"
+# ---------------------------------------------------------------------------
+
+def test_compare_uses_captured_branch_names_not_hardcoded() -> None:
+    """Branch names from caller args appear in the request URL, not hardcoded 'main'."""
+    compare_body = {"behind_by": 0, "ahead_by": 0, "status": "identical"}
+    resp = _make_rest_response(200, compare_body)
+
+    client = _make_client()
+    captured_requests: list[httpx.Request] = []
+
+    def fake_send(request: httpx.Request, **kwargs):
+        captured_requests.append(request)
+        return resp
+
+    with patch.object(client._client, "send", side_effect=fake_send):
+        client.compare_fork_upstream(
+            fork_owner="myorg",
+            fork_repo="myfork",
+            fork_default_branch="feature-branch",
+            parent_owner="upstream",
+            parent_default_branch="trunk",
+        )
+
+    assert len(captured_requests) == 1
+    url = str(captured_requests[0].url)
+    assert "feature-branch" in url, f"fork branch not in URL: {url}"
+    assert "trunk" in url, f"parent branch not in URL: {url}"
+    # Confirm 'main' is NOT hardcoded in this request (neither branch is 'main')
+    # The URL structure: compare/{parent}:{parent_branch}...{fork}:{fork_branch}
+    assert "upstream:trunk" in url
+    assert "myorg:feature-branch" in url
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Rate limit header warning when remaining < 10
+# ---------------------------------------------------------------------------
+
+def test_ratelimit_warning_when_remaining_low(caplog) -> None:
+    """Logger warning emitted when x-ratelimit-remaining < 10."""
+    import logging
+
+    compare_body = {"behind_by": 1, "ahead_by": 0, "status": "behind"}
+    resp = _make_rest_response(
+        200, compare_body, headers={"x-ratelimit-remaining": "3"}
+    )
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        with caplog.at_level(logging.WARNING, logger="pulse.gh_rest"):
+            client.compare_fork_upstream(
+                fork_owner="o", fork_repo="r",
+                fork_default_branch="main",
+                parent_owner="upstream", parent_default_branch="main",
+            )
+
+    assert any("rate limit" in rec.message.lower() or "remaining" in rec.message.lower()
+                for rec in caplog.records), \
+        f"Expected rate limit warning, got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Non-404 HTTP errors (401, 403) raise an exception
+# ---------------------------------------------------------------------------
+
+def test_compare_fork_upstream_401_raises() -> None:
+    """401 Unauthorized triggers raise_for_status → exception propagates."""
+    resp = _make_rest_response(401, text="Unauthorized")
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        with pytest.raises(httpx.HTTPStatusError):
+            client.compare_fork_upstream(
+                fork_owner="o", fork_repo="r",
+                fork_default_branch="main",
+                parent_owner="upstream", parent_default_branch="main",
+            )
+
+
+def test_compare_fork_upstream_403_raises() -> None:
+    """403 Forbidden triggers raise_for_status → exception propagates."""
+    resp = _make_rest_response(403, text="Forbidden")
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        with pytest.raises(httpx.HTTPStatusError):
+            client.compare_fork_upstream(
+                fork_owner="o", fork_repo="r",
+                fork_default_branch="main",
+                parent_owner="upstream", parent_default_branch="main",
+            )

--- a/tests/test_graphql_vuln.py
+++ b/tests/test_graphql_vuln.py
@@ -1,0 +1,235 @@
+"""tests/test_graphql_vuln.py — Vulnerability alerts GraphQL capture tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from pulse.graphql import GraphQLClient, ScopeMissing, VULN_ALERTS_QUERY
+from pulse.schema import VulnerabilityAlert
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_response(status_code: int, body: dict, headers: dict | None = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = body
+    resp.text = str(body)
+    resp.headers = headers or {}
+    return resp
+
+
+def _make_client() -> GraphQLClient:
+    with patch("pulse.graphql.apply_ipv4_patch"):
+        return GraphQLClient(token="test-token", force_ipv4=False)
+
+
+def _vuln_node(
+    ghsa_id: str = "GHSA-1234-5678-abcd",
+    package_name: str = "lodash",
+    ecosystem: str = "NPM",
+    severity: str = "HIGH",
+    published_at: str | None = None,
+    dep_pr_number: int | None = None,
+) -> dict:
+    if published_at is None:
+        # Default: 10 days ago
+        dt = datetime.now(timezone.utc) - timedelta(days=10)
+        published_at = dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    node: dict = {
+        "securityVulnerability": {
+            "severity": severity,
+            "package": {"name": package_name, "ecosystem": ecosystem},
+            "advisory": {"ghsaId": ghsa_id, "publishedAt": published_at},
+        },
+        "dependabotUpdate": None,
+        "createdAt": published_at,
+    }
+    if dep_pr_number is not None:
+        node["dependabotUpdate"] = {
+            "pullRequest": {"number": dep_pr_number, "updatedAt": published_at}
+        }
+    return node
+
+
+def _vuln_alerts_body(
+    nodes: list[dict],
+    has_next_page: bool = False,
+    end_cursor: str | None = None,
+    total_count: int | None = None,
+    cost: int = 1,
+    remaining: int = 4999,
+) -> dict:
+    return {
+        "data": {
+            "repository": {
+                "vulnerabilityAlerts": {
+                    "totalCount": total_count if total_count is not None else len(nodes),
+                    "pageInfo": {"hasNextPage": has_next_page, "endCursor": end_cursor},
+                    "nodes": nodes,
+                }
+            },
+            "rateLimit": {"cost": cost, "remaining": remaining},
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Single-page vuln alerts captured correctly
+# ---------------------------------------------------------------------------
+
+def test_single_page_vuln_alerts() -> None:
+    """Single page of vuln alerts captured — fields mapped correctly."""
+    node = _vuln_node(
+        ghsa_id="GHSA-aaaa-bbbb-cccc",
+        package_name="requests",
+        ecosystem="PIP",
+        severity="CRITICAL",
+        dep_pr_number=42,
+    )
+    resp = _make_response(200, _vuln_alerts_body([node]))
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        alerts = client.fetch_vuln_alerts("myorg", "myrepo")
+
+    assert len(alerts) == 1
+    a = alerts[0]
+    assert isinstance(a, VulnerabilityAlert)
+    assert a.ghsa_id == "GHSA-aaaa-bbbb-cccc"
+    assert a.package_name == "requests"
+    assert a.ecosystem == "PIP"
+    assert a.severity == "CRITICAL"
+    assert a.dependabot_pr_number == 42
+    assert a.age_days >= 0
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Multi-page pagination — all alerts concatenated
+# ---------------------------------------------------------------------------
+
+def test_multi_page_vuln_alerts_concatenated() -> None:
+    """Two pages of vuln alerts — both fetched, results concatenated."""
+    node1 = _vuln_node(ghsa_id="GHSA-0001-0001-0001", package_name="axios")
+    node2 = _vuln_node(ghsa_id="GHSA-0002-0002-0002", package_name="express")
+
+    page1_resp = _make_response(
+        200, _vuln_alerts_body([node1], has_next_page=True, end_cursor="cursor-p1")
+    )
+    page2_resp = _make_response(
+        200, _vuln_alerts_body([node2], has_next_page=False)
+    )
+
+    client = _make_client()
+    call_count = 0
+
+    def fake_send(request: httpx.Request, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return page1_resp if call_count == 1 else page2_resp
+
+    with patch.object(client._client, "send", side_effect=fake_send):
+        alerts = client.fetch_vuln_alerts("myorg", "myrepo")
+
+    assert len(alerts) == 2
+    ghsa_ids = {a.ghsa_id for a in alerts}
+    assert "GHSA-0001-0001-0001" in ghsa_ids
+    assert "GHSA-0002-0002-0002" in ghsa_ids
+
+
+# ---------------------------------------------------------------------------
+# Test 3: INSUFFICIENT_SCOPES → ScopeMissing raised, no crash
+# ---------------------------------------------------------------------------
+
+def test_insufficient_scopes_raises_scope_missing() -> None:
+    """INSUFFICIENT_SCOPES error in GraphQL response → ScopeMissing raised."""
+    scope_error_body = {
+        "data": None,
+        "errors": [
+            {
+                "type": "INSUFFICIENT_SCOPES",
+                "message": "Token requires security_events scope",
+            }
+        ],
+    }
+    resp = _make_response(200, scope_error_body)
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        with pytest.raises(ScopeMissing):
+            client.fetch_vuln_alerts("myorg", "myrepo")
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Dedup — same ghsa_id different packages → 2 separate entries
+# ---------------------------------------------------------------------------
+
+def test_dedup_same_advisory_different_packages() -> None:
+    """Same GHSA ID affecting different packages → 2 separate VulnerabilityAlert entries."""
+    node1 = _vuln_node(ghsa_id="GHSA-shared-0001", package_name="pkg-a", ecosystem="NPM")
+    node2 = _vuln_node(ghsa_id="GHSA-shared-0001", package_name="pkg-b", ecosystem="NPM")
+
+    resp = _make_response(200, _vuln_alerts_body([node1, node2]))
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        alerts = client.fetch_vuln_alerts("myorg", "myrepo")
+
+    assert len(alerts) == 2
+    package_names = {a.package_name for a in alerts}
+    assert "pkg-a" in package_names
+    assert "pkg-b" in package_names
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Same (ghsa_id, package_name) duplicate → deduplicated to 1 entry
+# ---------------------------------------------------------------------------
+
+def test_dedup_exact_duplicate_collapsed() -> None:
+    """Exact same (ghsa_id, package_name) appearing twice → deduplicated to 1 entry."""
+    node1 = _vuln_node(ghsa_id="GHSA-dup-dup-dup", package_name="same-pkg")
+    node2 = _vuln_node(ghsa_id="GHSA-dup-dup-dup", package_name="same-pkg")
+
+    resp = _make_response(200, _vuln_alerts_body([node1, node2]))
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        alerts = client.fetch_vuln_alerts("myorg", "myrepo")
+
+    assert len(alerts) == 1
+    assert alerts[0].ghsa_id == "GHSA-dup-dup-dup"
+    assert alerts[0].package_name == "same-pkg"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Severity preserved verbatim — CRITICAL, HIGH, MODERATE, LOW
+# ---------------------------------------------------------------------------
+
+def test_severity_preserved_verbatim() -> None:
+    """Severity values CRITICAL, HIGH, MODERATE, LOW preserved verbatim from GitHub."""
+    severities = ["CRITICAL", "HIGH", "MODERATE", "LOW"]
+    nodes = [
+        _vuln_node(
+            ghsa_id=f"GHSA-sev-{sev[:4].lower()}-0001",
+            package_name=f"pkg-{i}",
+            severity=sev,
+        )
+        for i, sev in enumerate(severities)
+    ]
+    resp = _make_response(200, _vuln_alerts_body(nodes))
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        alerts = client.fetch_vuln_alerts("myorg", "myrepo")
+
+    assert len(alerts) == 4
+    alert_severities = {a.severity for a in alerts}
+    for sev in severities:
+        assert sev in alert_severities, f"Severity {sev} not found in alerts"


### PR DESCRIPTION
## Summary
- `pulse/gh_rest.py`: thin REST client for fork upstream compare (GraphQL can't do cross-repo)
- Fork upstream delta written to `repos.upstream` JSON blob; uses captured default_branch names (never hardcoded)
- `vulnerabilityAlerts` GraphQL query with pagination; `INSUFFICIENT_SCOPES` surfaces as loud digest alert
- Alert dedup by (ghsa_id, package_name) — same advisory across deps = separate entries
- `create_schema()` aligned: `repos.upstream` + `repos.vulnerability_alerts` columns added for fresh installs
- `UpstreamStatus` + `VulnerabilityAlert` Pydantic models in `schema.py`
- `parent_default_branch` added to `RepoData` + REPOS_QUERY fetches `parent { defaultBranchRef { name } }`
- `tests/test_gh_rest.py` + `tests/test_graphql_vuln.py`: 12 tests combined; full suite 104 passed

Closes #48