### PR TITLE
feat(pulse): v1 7-day reviewer activity rollup + warm-up banner (#49)

### DIFF
--- a/pulse/digest.py
+++ b/pulse/digest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
 import sqlite3
@@ -8,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from pulse.config import PulseConfig
+from pulse.rollup import count_snapshots_in_last_7d, oldest_snapshot_in_7d
 
 
 def md_escape(s: object, max_len: int = 120) -> str:
@@ -59,6 +61,60 @@ def atomic_write_text(path: Path, text: str) -> None:
         except FileNotFoundError:
             pass
         raise
+
+
+def _render_reviewer_activity(
+    db_conn: sqlite3.Connection,
+    snap: sqlite3.Row,
+    cfg: PulseConfig,
+) -> list[str]:
+    lines: list[str] = []
+    lines.append("## Reviewer Activity (7d)")
+    lines.append("")
+
+    # Warm-up banner calculation
+    cadence_minutes = cfg.defaults.cadence_minutes
+    full_window_snapshots = int(7 * 24 * 60 / cadence_minutes)
+    actual_count = count_snapshots_in_last_7d(db_conn)
+
+    if actual_count < full_window_snapshots:
+        oldest_utc = oldest_snapshot_in_7d(db_conn)
+        if oldest_utc:
+            oldest_dt = datetime.fromisoformat(oldest_utc.replace("Z", "+00:00"))
+            fill_date = (oldest_dt + dt.timedelta(days=7)).strftime("%Y-%m-%d")
+            days_so_far = max(1, actual_count * cadence_minutes // (24 * 60))
+            lines.append(
+                f"_Reviewer activity: showing {days_so_far} day(s) of data "
+                f"(7-day window fills at {fill_date})_"
+            )
+        else:
+            lines.append("_Reviewer activity: no data yet_")
+        lines.append("")
+
+    # Read cached rollup from snapshot row
+    rollup_json = snap["reviewer_activity_7d"]
+    if not rollup_json:
+        lines.append("_No reviewer activity data computed for this snapshot._")
+        lines.append("")
+        return lines
+
+    rollup = json.loads(rollup_json)
+    if not rollup:
+        lines.append("_No review events in last 7 days._")
+        lines.append("")
+        return lines
+
+    for bucket, counts in sorted(rollup.items()):
+        bucket_escaped = md_escape(bucket)
+        total = counts.get("total", 0)
+        approved = counts.get("approved", 0)
+        cr = counts.get("change_requested", 0)
+        lines.append(
+            f"- **{bucket_escaped}**: {total} events "
+            f"({approved} approved, {cr} changes requested)"
+        )
+    lines.append("")
+    return lines
 
 
 def _latest_snapshot(db_conn: sqlite3.Connection) -> sqlite3.Row | None:
@@ -242,6 +298,9 @@ def render_digest(db_conn: sqlite3.Connection, cfg: PulseConfig) -> str:
     if not repos_with_dependabot_prs:
         lines.append("_No open Dependabot PRs._")
     lines.append("")
+
+    # ---- Reviewer Activity (7d) ----
+    lines.extend(_render_reviewer_activity(db_conn, snap, cfg))
 
     # ---- Footer ----
     # Rate limit remaining: pull from latest snapshot via a stored value if available,

--- a/pulse/digest.py
+++ b/pulse/digest.py
@@ -82,10 +82,8 @@ def _render_reviewer_activity(
         if oldest_utc:
             oldest_dt = datetime.fromisoformat(oldest_utc.replace("Z", "+00:00"))
             fill_date = (oldest_dt + dt.timedelta(days=7)).strftime("%Y-%m-%d")
-            days_so_far = max(1, actual_count * cadence_minutes // (24 * 60))
             lines.append(
-                f"_Reviewer activity: showing {days_so_far} day(s) of data "
-                f"(7-day window fills at {fill_date})_"
+                f"_Reviewer activity: {actual_count} snapshot(s) collected — 7-day window fills at {fill_date}_"
             )
         else:
             lines.append("_Reviewer activity: no data yet_")

--- a/pulse/migrate.py
+++ b/pulse/migrate.py
@@ -128,6 +128,8 @@ def run_migration(db_path: Path) -> str:
             conn.execute("ALTER TABLE prs ADD COLUMN node_id TEXT")
         if not _column_exists(conn, "prs", "review_events"):
             conn.execute("ALTER TABLE prs ADD COLUMN review_events TEXT")
+        if not _column_exists(conn, "snapshots", "reviewer_activity_7d"):
+            conn.execute("ALTER TABLE snapshots ADD COLUMN reviewer_activity_7d TEXT")
 
         # Fix 4: integrity_check BEFORE user_version bump
         # If check fails, DB is NOT permanently tagged v1

--- a/pulse/rollup.py
+++ b/pulse/rollup.py
@@ -81,17 +81,17 @@ def compute_reviewer_activity_7d(conn: sqlite3.Connection) -> dict:
         if bucket not in buckets:
             buckets[bucket] = {"total": 0, "approved": 0, "change_requested": 0, "commented": 0, "dismissed": 0}
         b = buckets[bucket]
-        b["total"] += 1
-        if state == "APPROVED":
-            b["approved"] += 1
-        elif state == "CHANGES_REQUESTED":
-            b["change_requested"] += 1
-        elif event_type == "IssueComment" or (state in ("COMMENTED", None) and event_type == "PULL_REQUEST_REVIEW"):
-            b["commented"] += 1
-        elif state == "DISMISSED":
-            b["dismissed"] += 1
-        elif event_type in ("REVIEW_REQUESTED_EVENT", "MERGED_EVENT", "CLOSED_EVENT", "LABELED_EVENT", "REFERENCED_EVENT"):
-            pass  # non-review events — count in total but not in sub-buckets
+        if event_type in ("PULL_REQUEST_REVIEW", "IssueComment"):
+            b["total"] += 1
+            if state == "APPROVED":
+                b["approved"] += 1
+            elif state == "CHANGES_REQUESTED":
+                b["change_requested"] += 1
+            elif event_type == "IssueComment" or state in ("COMMENTED", None):
+                b["commented"] += 1
+            elif state == "DISMISSED":
+                b["dismissed"] += 1
+        # non-review timeline events (MERGED_EVENT, etc.) — not counted in any bucket
 
     return buckets
 

--- a/pulse/rollup.py
+++ b/pulse/rollup.py
@@ -1,0 +1,114 @@
+"""pulse/rollup.py — 7-day reviewer activity rollup."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import sqlite3
+import time
+from datetime import datetime, timezone
+
+from pulse.snapshot import DEPENDABOT_AUTHORS, RENOVATE_AUTHORS
+
+COPILOT_AUTHORS = frozenset({"Copilot", "copilot-pull-request-reviewer[bot]"})
+GEMINI_CA_AUTHORS = frozenset({"gemini-code-assist", "gemini-code-assist[bot]"})
+CLAUDE_SUBAGENT_AUTHORS = frozenset({
+    "claude-subagent", "claude-code", "anthropic-claude", "claude-ai"
+    # PR Review Toolkit bot patterns — extend as needed
+})
+
+_log = logging.getLogger(__name__)
+
+
+def classify_author(author: str) -> str:
+    """Return bucket key for a reviewer author login."""
+    if author in COPILOT_AUTHORS:
+        return "copilot"
+    if author in GEMINI_CA_AUTHORS:
+        return "gemini-ca"
+    if author in CLAUDE_SUBAGENT_AUTHORS:
+        return "claude-subagent"
+    if author in DEPENDABOT_AUTHORS:
+        return "dependabot"
+    if author in RENOVATE_AUTHORS:
+        return "renovate"
+    return f"human:{author}"
+
+
+def _seven_days_ago_iso() -> str:
+    return (datetime.now(timezone.utc) - dt.timedelta(days=7)).isoformat().replace("+00:00", "Z")
+
+
+def compute_reviewer_activity_7d(conn: sqlite3.Connection) -> dict:
+    """
+    Query prs.review_events JSON blobs across last 7 days via json_each.
+    Returns bucketed reviewer activity dict.
+    Uses SQLite JSON1 extension — no Python-side deserialization for filtering.
+    """
+    seven_days_ago = _seven_days_ago_iso()
+
+    start = time.monotonic()
+
+    rows = conn.execute("""
+        SELECT
+            json_extract(evt.value, '$.author') as author,
+            json_extract(evt.value, '$.state') as state,
+            json_extract(evt.value, '$.type') as type
+        FROM snapshots s
+        JOIN repos r ON r.snapshot_id = s.id
+        JOIN prs p ON p.repo_id = r.id,
+        json_each(p.review_events) AS evt
+        WHERE s.captured_at_utc >= ?
+          AND s.capture_status != 'failed'
+          AND p.review_events IS NOT NULL
+          AND p.review_events != 'null'
+    """, (seven_days_ago,)).fetchall()
+
+    elapsed = time.monotonic() - start
+    if elapsed > 2.0:
+        _log.warning("reviewer_activity_7d rollup took %.2fs — consider indexing", elapsed)
+
+    buckets: dict[str, dict] = {}
+
+    for author, state, event_type in rows:
+        if not author:
+            continue
+        bucket = classify_author(author)
+        if bucket not in buckets:
+            buckets[bucket] = {"total": 0, "approved": 0, "change_requested": 0, "commented": 0, "dismissed": 0}
+        b = buckets[bucket]
+        b["total"] += 1
+        if state == "APPROVED":
+            b["approved"] += 1
+        elif state == "CHANGES_REQUESTED":
+            b["change_requested"] += 1
+        elif state in ("COMMENTED", None) and event_type == "PULL_REQUEST_REVIEW":
+            b["commented"] += 1
+        elif state == "DISMISSED":
+            b["dismissed"] += 1
+        elif event_type in ("REVIEW_REQUESTED_EVENT", "MERGED_EVENT", "CLOSED_EVENT", "LABELED_EVENT", "REFERENCED_EVENT"):
+            pass  # non-review events — count in total but not in sub-buckets
+
+    return buckets
+
+
+def count_snapshots_in_last_7d(conn: sqlite3.Connection) -> int:
+    """Count completed snapshots within the last 7 days."""
+    seven_days_ago = _seven_days_ago_iso()
+    row = conn.execute("""
+        SELECT count(*) FROM snapshots
+        WHERE captured_at_utc >= ? AND capture_status != 'failed'
+    """, (seven_days_ago,)).fetchone()
+    return row[0] if row else 0
+
+
+def oldest_snapshot_in_7d(conn: sqlite3.Connection) -> str | None:
+    """Return captured_at_utc of oldest snapshot in 7-day window."""
+    seven_days_ago = _seven_days_ago_iso()
+    row = conn.execute("""
+        SELECT captured_at_utc FROM snapshots
+        WHERE captured_at_utc >= ? AND capture_status != 'failed'
+        ORDER BY captured_at_utc ASC LIMIT 1
+    """, (seven_days_ago,)).fetchone()
+    return row[0] if row else None

--- a/pulse/rollup.py
+++ b/pulse/rollup.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime as dt
-import json
 import logging
 import sqlite3
 import time
@@ -55,15 +54,19 @@ def compute_reviewer_activity_7d(conn: sqlite3.Connection) -> dict:
             json_extract(evt.value, '$.author') as author,
             json_extract(evt.value, '$.state') as state,
             json_extract(evt.value, '$.type') as type
-        FROM snapshots s
-        JOIN repos r ON r.snapshot_id = s.id
+        FROM (
+            SELECT MAX(id) as snap_id FROM snapshots
+            WHERE capture_status != 'failed'
+              AND captured_at_utc >= ?
+        ) latest
+        JOIN repos r ON r.snapshot_id = latest.snap_id
         JOIN prs p ON p.repo_id = r.id,
         json_each(p.review_events) AS evt
-        WHERE s.captured_at_utc >= ?
-          AND s.capture_status != 'failed'
-          AND p.review_events IS NOT NULL
+        WHERE p.review_events IS NOT NULL
           AND p.review_events != 'null'
-    """, (seven_days_ago,)).fetchall()
+          AND (json_extract(evt.value, '$.submitted_at') >= ?
+               OR json_extract(evt.value, '$.submitted_at') IS NULL)
+    """, (seven_days_ago, seven_days_ago)).fetchall()
 
     elapsed = time.monotonic() - start
     if elapsed > 2.0:
@@ -83,7 +86,7 @@ def compute_reviewer_activity_7d(conn: sqlite3.Connection) -> dict:
             b["approved"] += 1
         elif state == "CHANGES_REQUESTED":
             b["change_requested"] += 1
-        elif state in ("COMMENTED", None) and event_type == "PULL_REQUEST_REVIEW":
+        elif event_type == "IssueComment" or (state in ("COMMENTED", None) and event_type == "PULL_REQUEST_REVIEW"):
             b["commented"] += 1
         elif state == "DISMISSED":
             b["dismissed"] += 1

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -999,6 +999,21 @@ def run_snapshot(
         capture_status=snapshot_capture_status,
     )
 
+    # Compute and cache 7-day reviewer activity rollup
+    # Local import to avoid circular dependency (rollup imports DEPENDABOT_AUTHORS from this module)
+    try:
+        from pulse.rollup import compute_reviewer_activity_7d
+        rollup = compute_reviewer_activity_7d(db_conn)
+        with db_conn:
+            db_conn.execute(
+                "UPDATE snapshots SET reviewer_activity_7d=? WHERE id=?",
+                (json.dumps(rollup), snapshot_id),
+            )
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            "reviewer_activity_7d rollup failed for snapshot %s: %s", snapshot_id, e
+        )
+
     # Write JSON artifacts
     if output_dir is not None:
         current_data = _build_current_json(db_conn, snapshot_id)

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -133,7 +133,8 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 repos_failed INTEGER NOT NULL DEFAULT 0,
                 repos_partial INTEGER NOT NULL DEFAULT 0,
                 schema_version TEXT NOT NULL DEFAULT '1.0',
-                capture_status TEXT NOT NULL DEFAULT 'success'
+                capture_status TEXT NOT NULL DEFAULT 'success',
+                reviewer_activity_7d TEXT   -- JSON blob: {bucket: {total, approved, change_requested, commented, dismissed}}
             )
         """)
         conn.execute("""

--- a/tests/test_rollup.py
+++ b/tests/test_rollup.py
@@ -273,3 +273,41 @@ def test_warmup_banner_absent_when_full_window() -> None:
     lines = _render_reviewer_activity(conn, snap, cfg)
     combined = "\n".join(lines)
     assert "7-day window fills at" not in combined
+
+
+def test_non_review_events_excluded_from_total() -> None:
+    """Non-review timeline events (MERGED_EVENT etc.) must not inflate total."""
+    events = [
+        {"type": "PULL_REQUEST_REVIEW", "author": "alice", "state": "APPROVED",
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "MERGED_EVENT", "author": "alice", "state": None,
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "LABELED_EVENT", "author": "alice", "state": None,
+         "label": None, "submitted_at": None, "created_at": None},
+    ]
+    conn = _db_with_events(events)
+    result = compute_reviewer_activity_7d(conn)
+    # Only the PULL_REQUEST_REVIEW counts — MERGED_EVENT and LABELED_EVENT must not inflate total
+    assert result == {"human:alice": {"total": 1, "approved": 1, "change_requested": 0, "commented": 0, "dismissed": 0}}
+
+
+def test_no_double_count_across_snapshots() -> None:
+    """Non-review events mixed with review events across multiple snapshots must not inflate total."""
+    conn = _make_db()
+    # Each snapshot has 1 review + 2 non-review events
+    events = [
+        {"type": "PULL_REQUEST_REVIEW", "author": "alice", "state": "APPROVED",
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "MERGED_EVENT", "author": "alice", "state": None,
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "CLOSED_EVENT", "author": "alice", "state": None,
+         "label": None, "submitted_at": None, "created_at": None},
+    ]
+    for i in range(3):
+        snap_id = f"multi-snap-{i}"
+        _insert_snapshot(conn, snap_id, _utc_iso(0.5))
+        repo_id = _insert_repo(conn, snap_id)
+        _insert_pr_with_events(conn, repo_id, 1, events)
+    rollup = compute_reviewer_activity_7d(conn)
+    # SQL uses MAX(id) — only the latest snapshot is queried; non-review events (MERGED, CLOSED) excluded from total
+    assert rollup == {"human:alice": {"total": 1, "approved": 1, "change_requested": 0, "commented": 0, "dismissed": 0}}

--- a/tests/test_rollup.py
+++ b/tests/test_rollup.py
@@ -1,0 +1,275 @@
+"""tests/test_rollup.py — 7-day reviewer activity rollup tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from pulse.rollup import (
+    classify_author,
+    compute_reviewer_activity_7d,
+    count_snapshots_in_last_7d,
+    oldest_snapshot_in_7d,
+)
+from pulse.snapshot import DEPENDABOT_AUTHORS, RENOVATE_AUTHORS
+from pulse.storage import create_schema
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    create_schema(conn)
+    return conn
+
+
+def _utc_iso(offset_days: float = 0) -> str:
+    """Return an ISO-8601 UTC string offset from now."""
+    ts = datetime.now(timezone.utc) - timedelta(days=offset_days)
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _insert_snapshot(
+    conn: sqlite3.Connection,
+    snapshot_id: str,
+    captured_at_utc: str,
+    capture_status: str = "success",
+) -> str:
+    conn.execute(
+        """
+        INSERT INTO snapshots
+          (id, captured_at_utc, captured_at_et, duration_ms, orgs_queried,
+           repos_succeeded, repos_failed, repos_partial, schema_version, capture_status)
+        VALUES (?, ?, '2026-01-01 00:00 ET', 500, ?, 1, 0, 0, '1.0', ?)
+        """,
+        (snapshot_id, captured_at_utc, json.dumps(["testorg"]), capture_status),
+    )
+    conn.commit()
+    return snapshot_id
+
+
+def _insert_repo(conn: sqlite3.Connection, snapshot_id: str) -> int:
+    cur = conn.execute(
+        """
+        INSERT INTO repos
+          (snapshot_id, org, name, default_branch, is_fork, is_archived,
+           parent_owner, parent_name, parent_is_deleted, capture_status, field_statuses)
+        VALUES (?, 'testorg', 'testrepo', 'main', 0, 0, NULL, NULL, 0, 'success', '{}')
+        """,
+        (snapshot_id,),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _insert_pr_with_events(
+    conn: sqlite3.Connection,
+    repo_id: int,
+    pr_number: int,
+    events: list[dict],
+) -> None:
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO prs
+          (repo_id, number, title, author, created_at, updated_at,
+           is_draft, is_dependabot, is_renovate, hours_idle, stalled, review_events)
+        VALUES (?, ?, 'Test PR', 'testuser', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                0, 0, 0, 1.0, 0, ?)
+        """,
+        (repo_id, pr_number, json.dumps(events)),
+    )
+    conn.commit()
+
+
+def _db_with_events(events: list[dict], days_ago: float = 0.5) -> sqlite3.Connection:
+    """Convenience: create an in-memory DB with one snapshot/repo/PR containing the given events."""
+    conn = _make_db()
+    snap_id = f"snap-{days_ago}"
+    captured_at = _utc_iso(days_ago)
+    _insert_snapshot(conn, snap_id, captured_at)
+    repo_id = _insert_repo(conn, snap_id)
+    _insert_pr_with_events(conn, repo_id, 1, events)
+    return conn
+
+
+# ── classify_author tests ─────────────────────────────────────────────────────
+
+def test_classify_copilot() -> None:
+    assert classify_author("Copilot") == "copilot"
+    assert classify_author("copilot-pull-request-reviewer[bot]") == "copilot"
+
+
+def test_classify_gemini_ca() -> None:
+    assert classify_author("gemini-code-assist") == "gemini-ca"
+    assert classify_author("gemini-code-assist[bot]") == "gemini-ca"
+
+
+def test_classify_claude_subagent() -> None:
+    assert classify_author("claude-subagent") == "claude-subagent"
+    assert classify_author("claude-code") == "claude-subagent"
+
+
+def test_classify_dependabot() -> None:
+    # Must reuse the imported set — pick one entry from the actual constant
+    for author in DEPENDABOT_AUTHORS:
+        assert classify_author(author) == "dependabot"
+
+
+def test_classify_renovate() -> None:
+    for author in RENOVATE_AUTHORS:
+        assert classify_author(author) == "renovate"
+
+
+def test_classify_human() -> None:
+    assert classify_author("liam") == "human:liam"
+    assert classify_author("octocat") == "human:octocat"
+
+
+# ── compute_reviewer_activity_7d tests ───────────────────────────────────────
+
+def test_7d_filter_excludes_old_snapshots() -> None:
+    """Events in snapshots older than 7 days must not appear in the rollup."""
+    events = [{"type": "PULL_REQUEST_REVIEW", "author": "liam", "state": "APPROVED",
+                "label": None, "submitted_at": None, "created_at": None}]
+    conn = _db_with_events(events, days_ago=8.0)  # 8 days ago — outside window
+    result = compute_reviewer_activity_7d(conn)
+    assert result == {}
+
+
+def test_empty_window_returns_empty_rollup() -> None:
+    """No snapshots in 7d → empty dict."""
+    conn = _make_db()
+    result = compute_reviewer_activity_7d(conn)
+    assert result == {}
+
+
+def test_multiple_buckets_counted_correctly() -> None:
+    """Multiple distinct reviewers produce separate buckets with correct counts."""
+    events = [
+        {"type": "PULL_REQUEST_REVIEW", "author": "liam", "state": "APPROVED",
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "PULL_REQUEST_REVIEW", "author": "liam", "state": "APPROVED",
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "PULL_REQUEST_REVIEW", "author": "Copilot", "state": "CHANGES_REQUESTED",
+         "label": None, "submitted_at": None, "created_at": None},
+    ]
+    conn = _db_with_events(events)
+    result = compute_reviewer_activity_7d(conn)
+
+    assert "human:liam" in result
+    assert result["human:liam"]["total"] == 2
+    assert result["human:liam"]["approved"] == 2
+    assert result["human:liam"]["change_requested"] == 0
+
+    assert "copilot" in result
+    assert result["copilot"]["total"] == 1
+    assert result["copilot"]["change_requested"] == 1
+
+
+def test_rollup_cached_to_snapshot_row() -> None:
+    """compute_reviewer_activity_7d result can be written and re-read from snapshots table."""
+    events = [{"type": "PULL_REQUEST_REVIEW", "author": "alice", "state": "APPROVED",
+               "label": None, "submitted_at": None, "created_at": None}]
+    conn = _db_with_events(events)
+
+    rollup = compute_reviewer_activity_7d(conn)
+    snap_id = conn.execute("SELECT id FROM snapshots LIMIT 1").fetchone()[0]
+    conn.execute(
+        "UPDATE snapshots SET reviewer_activity_7d=? WHERE id=?",
+        (json.dumps(rollup), snap_id),
+    )
+    conn.commit()
+
+    row = conn.execute(
+        "SELECT reviewer_activity_7d FROM snapshots WHERE id=?", (snap_id,)
+    ).fetchone()
+    assert row is not None
+    cached = json.loads(row[0])
+    assert "human:alice" in cached
+    assert cached["human:alice"]["approved"] == 1
+
+
+def test_failed_snapshot_excluded() -> None:
+    """Snapshots with capture_status='failed' are excluded from the rollup."""
+    conn = _make_db()
+    snap_id = "failed-snap"
+    _insert_snapshot(conn, snap_id, _utc_iso(0.5), capture_status="failed")
+    repo_id = _insert_repo(conn, snap_id)
+    events = [{"type": "PULL_REQUEST_REVIEW", "author": "bob", "state": "APPROVED",
+               "label": None, "submitted_at": None, "created_at": None}]
+    _insert_pr_with_events(conn, repo_id, 1, events)
+
+    result = compute_reviewer_activity_7d(conn)
+    assert result == {}
+
+
+# ── count_snapshots_in_last_7d tests ─────────────────────────────────────────
+
+def test_count_snapshots_excludes_old() -> None:
+    conn = _make_db()
+    _insert_snapshot(conn, "recent", _utc_iso(1.0))
+    _insert_snapshot(conn, "old", _utc_iso(8.0))
+    assert count_snapshots_in_last_7d(conn) == 1
+
+
+def test_count_snapshots_excludes_failed() -> None:
+    conn = _make_db()
+    _insert_snapshot(conn, "ok", _utc_iso(1.0))
+    _insert_snapshot(conn, "bad", _utc_iso(0.5), capture_status="failed")
+    assert count_snapshots_in_last_7d(conn) == 1
+
+
+# ── warm-up banner integration ────────────────────────────────────────────────
+
+def test_warmup_banner_renders_with_fill_date() -> None:
+    """When actual_count < full_window_snapshots, digest shows warm-up banner with fill date."""
+    from pulse.config import Defaults, OrgConfig, PulseConfig
+    from pulse.digest import _render_reviewer_activity
+
+    conn = _make_db()
+    snap_id = "snap-recent"
+    captured_at = _utc_iso(1.0)
+    _insert_snapshot(conn, snap_id, captured_at)
+
+    # Read the snapshot row
+    snap = conn.execute("SELECT * FROM snapshots WHERE id=?", (snap_id,)).fetchone()
+
+    cfg = PulseConfig(
+        schema_version="1.0",
+        orgs={"testorg": OrgConfig()},
+        defaults=Defaults(cadence_minutes=30),
+    )
+
+    lines = _render_reviewer_activity(conn, snap, cfg)
+    combined = "\n".join(lines)
+    # With 1 snapshot and cadence_minutes=30, full window = 336 snapshots — far short
+    assert "7-day window fills at" in combined
+
+
+def test_warmup_banner_absent_when_full_window() -> None:
+    """When actual_count >= full_window_snapshots, no warm-up banner."""
+    from pulse.config import Defaults, OrgConfig, PulseConfig
+    from pulse.digest import _render_reviewer_activity
+
+    conn = _make_db()
+
+    # Use cadence_minutes=10080 so full_window_snapshots=1 — one snapshot satisfies it
+    cfg = PulseConfig(
+        schema_version="1.0",
+        orgs={"testorg": OrgConfig()},
+        defaults=Defaults(cadence_minutes=10080),
+    )
+
+    snap_id = "snap-full"
+    _insert_snapshot(conn, snap_id, _utc_iso(0.5))
+    snap = conn.execute("SELECT * FROM snapshots WHERE id=?", (snap_id,)).fetchone()
+
+    lines = _render_reviewer_activity(conn, snap, cfg)
+    combined = "\n".join(lines)
+    assert "7-day window fills at" not in combined


### PR DESCRIPTION
## Summary
- `pulse/rollup.py`: 7-day reviewer activity rollup via json_each; 5 bot buckets (copilot, gemini-ca, claude-subagent, dependabot, renovate) + human:<login>
- Reuses `DEPENDABOT_AUTHORS` + `RENOVATE_AUTHORS` from snapshot.py (local import to break circular dep)
- Rollup cached to `snapshots.reviewer_activity_7d` JSON blob after each `run_snapshot()`
- Digest: new `## Reviewer Activity (7d)` section with cadence-aware warm-up banner showing fill date
- `create_schema()` + `migrate.py` both add `snapshots.reviewer_activity_7d TEXT` column (idempotent)
- 15 tests in `tests/test_rollup.py` covering all 5 bot buckets, human fallback, 7d filter, failed snapshot exclusion, warm-up banner on/off, rollup cache write, multi-bucket counting

Closes #49