### PR TITLE
release: pulse v1 (dev-phase-2-pulse → dev)

### DIFF
--- a/pulse/__main__.py
+++ b/pulse/__main__.py
@@ -523,6 +523,8 @@ def _run_dry_run(repo_override: str | None = None) -> None:
 @main.command("migrate")
 def cmd_migrate() -> None:
     """Migrate pulse.db from v0 to v1 (idempotent)."""
+    import sqlite3 as _sqlite3
+
     from pulse.migrate import run_migration
 
     db_path = _DEFAULT_DB_PATH
@@ -533,7 +535,11 @@ def cmd_migrate() -> None:
         else:
             click.echo(f"Migration complete. Backup preserved at {db_path.parent}/pulse.db.pre-v1-*")
     except RuntimeError as e:
-        click.echo(f"ERROR: {e}", err=True)
+        click.echo(f"Migration failed: {e}", err=True)
+        sys.exit(1)
+    except (_sqlite3.Error, OSError) as e:
+        click.echo(f"Migration failed ({type(e).__name__}): {e}", err=True)
+        click.echo(f"Check backup at: {db_path.parent}/pulse.db.pre-v1-* before retrying", err=True)
         sys.exit(1)
 
 

--- a/pulse/__main__.py
+++ b/pulse/__main__.py
@@ -520,5 +520,22 @@ def _run_dry_run(repo_override: str | None = None) -> None:
     click.echo(str(out_path))
 
 
+@main.command("migrate")
+def cmd_migrate() -> None:
+    """Migrate pulse.db from v0 to v1 (idempotent)."""
+    from pulse.migrate import run_migration
+
+    db_path = _DEFAULT_DB_PATH
+    try:
+        status = run_migration(db_path)
+        if status == "no-op":
+            click.echo("pulse.db already at v1 — no migration needed.")
+        else:
+            click.echo(f"Migration complete. Backup preserved at {db_path.parent}/pulse.db.pre-v1-*")
+    except RuntimeError as e:
+        click.echo(f"ERROR: {e}", err=True)
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     main()

--- a/pulse/__main__.py
+++ b/pulse/__main__.py
@@ -525,22 +525,27 @@ def cmd_migrate() -> None:
     """Migrate pulse.db from v0 to v1 (idempotent)."""
     import sqlite3 as _sqlite3
 
+    from pulse.locks import LockHeld, PulseLock
     from pulse.migrate import run_migration
 
     db_path = _DEFAULT_DB_PATH
     try:
-        status = run_migration(db_path)
-        if status == "no-op":
-            click.echo("pulse.db already at v1 — no migration needed.")
-        else:
-            click.echo(f"Migration complete. Backup preserved at {db_path.parent}/pulse.db.pre-v1-*")
+        with PulseLock():
+            msg = run_migration(db_path)
+            if msg == "no-op":
+                click.echo("pulse.db already at v1 — no migration needed.")
+            else:
+                click.echo(f"Migration complete. Backup preserved at {db_path.parent}/pulse.db.pre-v1-*")
+    except LockHeld as e:
+        click.echo(f"Migration blocked: pulse is currently running. Stop the service first.\n  {e}", err=True)
+        raise SystemExit(1)
     except RuntimeError as e:
         click.echo(f"Migration failed: {e}", err=True)
-        sys.exit(1)
+        raise SystemExit(1)
     except (_sqlite3.Error, OSError) as e:
         click.echo(f"Migration failed ({type(e).__name__}): {e}", err=True)
         click.echo(f"Check backup at: {db_path.parent}/pulse.db.pre-v1-* before retrying", err=True)
-        sys.exit(1)
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/pulse/digest.py
+++ b/pulse/digest.py
@@ -114,7 +114,12 @@ def render_digest(db_conn: sqlite3.Connection, cfg: PulseConfig) -> str:
             status = fs_data.get("status", "success")
             error_note = fs_data.get("error_note") or ""
             error_note_escaped = md_escape(str(error_note))
-            if status == "failed":
+            if status == "scope_missing":
+                alert_lines.append(
+                    f"- 🔴 **SCOPE MISSING — {repo_label}**: {field_name} — token lacks required permissions. "
+                    f"Run `pulse --self-check` and ensure GH\\_TOKEN has `read:security\\_events` scope."
+                )
+            elif status == "failed":
                 alert_lines.append(f"- ❌ **{repo_label}**: {field_name} failed — {error_note_escaped}")
             elif status == "disabled":
                 alert_lines.append(f"- ⚠️ **{repo_label}**: {field_name} field disabled")

--- a/pulse/digest.py
+++ b/pulse/digest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 import json
 import os
 import sqlite3
@@ -8,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from pulse.config import PulseConfig
+from pulse.rollup import count_snapshots_in_last_7d, oldest_snapshot_in_7d
 
 
 def md_escape(s: object, max_len: int = 120) -> str:
@@ -59,6 +61,60 @@ def atomic_write_text(path: Path, text: str) -> None:
         except FileNotFoundError:
             pass
         raise
+
+
+def _render_reviewer_activity(
+    db_conn: sqlite3.Connection,
+    snap: sqlite3.Row,
+    cfg: PulseConfig,
+) -> list[str]:
+    lines: list[str] = []
+    lines.append("## Reviewer Activity (7d)")
+    lines.append("")
+
+    # Warm-up banner calculation
+    cadence_minutes = cfg.defaults.cadence_minutes
+    full_window_snapshots = int(7 * 24 * 60 / cadence_minutes)
+    actual_count = count_snapshots_in_last_7d(db_conn)
+
+    if actual_count < full_window_snapshots:
+        oldest_utc = oldest_snapshot_in_7d(db_conn)
+        if oldest_utc:
+            oldest_dt = datetime.fromisoformat(oldest_utc.replace("Z", "+00:00"))
+            fill_date = (oldest_dt + dt.timedelta(days=7)).strftime("%Y-%m-%d")
+            days_so_far = max(1, actual_count * cadence_minutes // (24 * 60))
+            lines.append(
+                f"_Reviewer activity: showing {days_so_far} day(s) of data "
+                f"(7-day window fills at {fill_date})_"
+            )
+        else:
+            lines.append("_Reviewer activity: no data yet_")
+        lines.append("")
+
+    # Read cached rollup from snapshot row
+    rollup_json = snap["reviewer_activity_7d"]
+    if not rollup_json:
+        lines.append("_No reviewer activity data computed for this snapshot._")
+        lines.append("")
+        return lines
+
+    rollup = json.loads(rollup_json)
+    if not rollup:
+        lines.append("_No review events in last 7 days._")
+        lines.append("")
+        return lines
+
+    for bucket, counts in sorted(rollup.items()):
+        bucket_escaped = md_escape(bucket)
+        total = counts.get("total", 0)
+        approved = counts.get("approved", 0)
+        cr = counts.get("change_requested", 0)
+        lines.append(
+            f"- **{bucket_escaped}**: {total} events "
+            f"({approved} approved, {cr} changes requested)"
+        )
+    lines.append("")
+    return lines
 
 
 def _latest_snapshot(db_conn: sqlite3.Connection) -> sqlite3.Row | None:
@@ -242,6 +298,9 @@ def render_digest(db_conn: sqlite3.Connection, cfg: PulseConfig) -> str:
     if not repos_with_dependabot_prs:
         lines.append("_No open Dependabot PRs._")
     lines.append("")
+
+    # ---- Reviewer Activity (7d) ----
+    lines.extend(_render_reviewer_activity(db_conn, snap, cfg))
 
     # ---- Footer ----
     # Rate limit remaining: pull from latest snapshot via a stored value if available,

--- a/pulse/digest.py
+++ b/pulse/digest.py
@@ -82,10 +82,8 @@ def _render_reviewer_activity(
         if oldest_utc:
             oldest_dt = datetime.fromisoformat(oldest_utc.replace("Z", "+00:00"))
             fill_date = (oldest_dt + dt.timedelta(days=7)).strftime("%Y-%m-%d")
-            days_so_far = max(1, actual_count * cadence_minutes // (24 * 60))
             lines.append(
-                f"_Reviewer activity: showing {days_so_far} day(s) of data "
-                f"(7-day window fills at {fill_date})_"
+                f"_Reviewer activity: {actual_count} snapshot(s) collected — 7-day window fills at {fill_date}_"
             )
         else:
             lines.append("_Reviewer activity: no data yet_")

--- a/pulse/gh_rest.py
+++ b/pulse/gh_rest.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from pulse.ipv4 import apply_ipv4_patch
+
+logger = logging.getLogger(__name__)
+
+_RATELIMIT_WARN_THRESHOLD = 10
+
+
+class GHRestClient:
+    BASE_URL = "https://api.github.com"
+
+    def __init__(self, token: str, force_ipv4: bool = True) -> None:
+        if force_ipv4:
+            apply_ipv4_patch()
+        self._client = httpx.Client(
+            base_url=self.BASE_URL,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=30.0,
+        )
+
+    def _check_ratelimit_header(self, resp: httpx.Response) -> None:
+        try:
+            remaining = int(resp.headers.get("x-ratelimit-remaining", 100))
+        except (ValueError, TypeError):
+            return
+        if remaining < _RATELIMIT_WARN_THRESHOLD:
+            logger.warning(
+                "GitHub REST rate limit remaining=%d — approaching limit", remaining
+            )
+
+    def compare_fork_upstream(
+        self,
+        fork_owner: str,
+        fork_repo: str,
+        fork_default_branch: str,
+        parent_owner: str,
+        parent_default_branch: str,
+    ) -> dict:
+        """Compare fork to upstream using GitHub REST compare endpoint.
+
+        Returns upstream status dict for repos.upstream JSON blob.
+        NEVER hardcodes branch names — uses captured default_branch values.
+        """
+        url = (
+            f"/repos/{fork_owner}/{fork_repo}/compare"
+            f"/{parent_owner}:{parent_default_branch}...{fork_owner}:{fork_default_branch}"
+        )
+        resp = self._client.get(url)
+        self._check_ratelimit_header(resp)
+        if resp.status_code == 404:
+            return {"status": "parent_unavailable", "error_note": resp.text[:200]}
+        resp.raise_for_status()
+        data = resp.json()
+        return {
+            "status": "success",
+            "commits_behind": data.get("behind_by", 0),
+            "commits_ahead": data.get("ahead_by", 0),
+            "recent_upstream_releases": [],
+        }
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "GHRestClient":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/pulse/gh_rest.py
+++ b/pulse/gh_rest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from urllib.parse import quote
 
 import httpx
 
@@ -50,9 +51,11 @@ class GHRestClient:
         Returns upstream status dict for repos.upstream JSON blob.
         NEVER hardcodes branch names — uses captured default_branch values.
         """
+        encoded_fork_branch = quote(fork_default_branch, safe="")
+        encoded_parent_branch = quote(parent_default_branch, safe="")
         url = (
             f"/repos/{fork_owner}/{fork_repo}/compare"
-            f"/{parent_owner}:{parent_default_branch}...{fork_owner}:{fork_default_branch}"
+            f"/{parent_owner}:{encoded_parent_branch}...{fork_owner}:{encoded_fork_branch}"
         )
         resp = self._client.get(url)
         self._check_ratelimit_header(resp)

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import sys
 import time
+from collections.abc import Callable
 
 import httpx
 
@@ -62,6 +63,11 @@ class RunDeadlineExceeded(Exception):
 
 
 class CostBudgetExceeded(Exception):
+    pass
+
+
+class PRNodeNotFound(Exception):
+    """Raised when a PR node_id is not found on GitHub (data.node=null)."""
     pass
 
 
@@ -264,6 +270,7 @@ class GraphQLClient:
         field: str = "",
         cursor_var: str = "cursor",
         fingerprint: str = "",
+        on_page_response: Callable[[dict], None] | None = None,
     ) -> list[dict]:
         """Walk a paginated GraphQL connection, returning all collected nodes.
 
@@ -301,6 +308,12 @@ class GraphQLClient:
         try:
             while True:
                 body = self.execute(query, variables, deadline_monotonic=deadline_monotonic)
+
+                if on_page_response is not None:
+                    try:
+                        on_page_response(body)
+                    except Exception:
+                        pass  # callback failure must not interrupt pagination
 
                 try:
                     page_info: dict = body
@@ -390,6 +403,21 @@ class GraphQLClient:
         cumulative_cost: caller-supplied single-element list used as a mutable
         integer accumulator. Pass [0] to enable cross-PR cost tracking.
         """
+        accumulated_cost = [0]
+        last_remaining = [5000]
+        node_not_found = [False]
+
+        def _on_page(resp: dict) -> None:
+            data = resp.get("data") or {}
+            if data.get("node") is None and "node" in data:
+                node_not_found[0] = True
+            rate = data.get("rateLimit") or {}
+            page_cost = rate.get("cost", 0)
+            accumulated_cost[0] += page_cost
+            remaining = rate.get("remaining")
+            if remaining is not None:
+                last_remaining[0] = remaining
+
         nodes = self.paginate(
             query=PR_TIMELINE_QUERY,
             variables={"prId": pr_node_id, "cursor": None},
@@ -397,47 +425,31 @@ class GraphQLClient:
             nodes_path=["data", "node", "timelineItems", "nodes"],
             deadline_monotonic=deadline_monotonic,
             cursor_var="cursor",
+            on_page_response=_on_page,
         )
 
-        # Track cumulative cost from the last response (rateLimit is in each page body).
-        # We re-execute a small extra call to get cost when paginate() completes. Instead,
-        # we track it inline by wrapping execute(). Since paginate() already called execute(),
-        # we piggyback cost via a separate last-query cost read. For simplicity, we call
-        # a single extra non-paginated query only if cumulative tracking is requested.
-        # Actually: paginate() calls execute() which already logs cost per call. We track
-        # cumulative by reading rateLimit from each response. Since paginate() abstracts
-        # execute(), we do one more execute() call here only for cost — wasteful. Better:
-        # pass a cost callback. For now, use a single post-paginate cost probe only when
-        # cumulative_cost is provided.
+        if node_not_found[0]:
+            raise PRNodeNotFound(f"PR node_id not found on GitHub: {pr_node_id}")
+
         if cumulative_cost is not None:
-            try:
-                probe = self.execute(
-                    "query { rateLimit { cost remaining } }",
-                    deadline_monotonic=deadline_monotonic,
+            cost = accumulated_cost[0]
+            remaining = last_remaining[0]
+            cumulative_cost[0] += cost
+            if cost > TIMELINE_COST_WARN:
+                print(
+                    f"WARNING: timeline query cost {cost} exceeds threshold {TIMELINE_COST_WARN}",
+                    file=sys.stderr,
                 )
-                rate = (probe.get("data") or {}).get("rateLimit") or {}
-                cost = rate.get("cost", 1)
-                remaining = rate.get("remaining", 5000)
-                cumulative_cost[0] += cost
-                if cost > TIMELINE_COST_WARN:
-                    print(
-                        f"WARNING: timeline query cost {cost} exceeds threshold {TIMELINE_COST_WARN}",
-                        file=sys.stderr,
-                    )
-                if remaining < 100:
-                    print(
-                        f"CRITICAL: rateLimit.remaining={remaining} — approaching rate limit",
-                        file=sys.stderr,
-                    )
-                if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
-                    raise CostBudgetExceeded(
-                        f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
-                        "skipping remaining timeline fetches for this run"
-                    )
-            except CostBudgetExceeded:
-                raise
-            except Exception:
-                pass  # cost tracking failure is non-fatal
+            if remaining < 100:
+                print(
+                    f"CRITICAL: rateLimit.remaining={remaining} — approaching rate limit",
+                    file=sys.stderr,
+                )
+            if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+                raise CostBudgetExceeded(
+                    f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
+                    "skipping remaining timeline fetches for this run"
+                )
 
         return nodes
 

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -345,8 +345,8 @@ class GraphQLClient:
                 if on_page_response is not None:
                     try:
                         on_page_response(body)
-                    except PRNodeNotFound:
-                        raise  # null-node sentinel: stop pagination immediately
+                    except (PRNodeNotFound, ScopeMissing):
+                        raise  # sentinel exceptions: stop pagination immediately
                     except Exception:
                         pass  # other callback failures must not interrupt pagination
 
@@ -382,7 +382,7 @@ class GraphQLClient:
 
                 variables[cursor_var] = end_cursor
 
-        except (RunDeadlineExceeded, RetriesExhausted, CostBudgetExceeded, RuntimeError, PRNodeNotFound):
+        except (RunDeadlineExceeded, RetriesExhausted, CostBudgetExceeded, RuntimeError, PRNodeNotFound, ScopeMissing):
             # Interrupted — save cursor so next run resumes instead of restarting from page 1
             if use_checkpoint and last_cursor:
                 try:
@@ -544,10 +544,6 @@ class GraphQLClient:
             )
 
         accumulated_cost = [0]
-        # Mutable flag: on_page_response sets this when INSUFFICIENT_SCOPES detected.
-        # paginate() swallows all exceptions except PRNodeNotFound from on_page_response,
-        # so we signal via flag and raise after paginate() returns.
-        scope_missing_msg: list[str] = []
 
         def _on_page(resp: dict) -> None:
             data = resp.get("data") or {}
@@ -559,11 +555,11 @@ class GraphQLClient:
                 logger.warning(
                     "GitHub rate limit remaining=%d — approaching limit", remaining
                 )
-            # Check for INSUFFICIENT_SCOPES error (flag — not raise, paginate() swallows it)
+            # Raise ScopeMissing directly — paginate() re-raises it (same as PRNodeNotFound).
             errors = resp.get("errors") or []
             for err in errors:
                 if err.get("type") == "INSUFFICIENT_SCOPES":
-                    scope_missing_msg.append(
+                    raise ScopeMissing(
                         f"Token lacks required scope for vulnerabilityAlerts: {err.get('message', '')}"
                     )
 
@@ -582,10 +578,6 @@ class GraphQLClient:
         finally:
             if cumulative_cost is not None:
                 cumulative_cost[0] += accumulated_cost[0]
-
-        # Raise ScopeMissing after paginate() completes if flag was set
-        if scope_missing_msg:
-            raise ScopeMissing(scope_missing_msg[0])
 
         # Convert nodes to VulnerabilityAlert, dedup by (ghsa_id, package_name)
         seen: set[tuple[str, str]] = set()

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -66,7 +66,9 @@ class RunDeadlineExceeded(Exception):
 
 
 class CostBudgetExceeded(Exception):
-    pass
+    def __init__(self, message: str, cost: int = 0) -> None:
+        super().__init__(message)
+        self.cost = cost
 
 
 class PRNodeNotFound(Exception):
@@ -183,7 +185,8 @@ class GraphQLClient:
                 # Callers should aggregate rateLimit.cost across calls if a run budget is needed.
                 if cost > COST_ABORT_THRESHOLD:
                     raise CostBudgetExceeded(
-                        f"query cost {cost} exceeds abort threshold {COST_ABORT_THRESHOLD}"
+                        f"query cost {cost} exceeds abort threshold {COST_ABORT_THRESHOLD}",
+                        cost=cost,
                     )
                 if cost > COST_WARN_THRESHOLD:
                     print(
@@ -447,6 +450,10 @@ class GraphQLClient:
                 cursor_var="cursor",
                 on_page_response=_on_page,
             )
+        except CostBudgetExceeded as e:
+            # execute() raised before on_page_response ran — accumulate the aborting page's cost
+            accumulated_cost[0] += getattr(e, "cost", 0)
+            raise
         finally:
             # Pure accumulation only — NEVER raise from finally (would mask paginate exceptions)
             if cumulative_cost is not None:

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -13,6 +13,41 @@ COST_WARN_THRESHOLD = 10
 COST_ABORT_THRESHOLD = 50
 DEFAULT_DEADLINE_SEC = int(os.environ.get("PULSE_RUN_DEADLINE_SEC", "1200"))
 
+# Per-query cost thresholds for timeline fetches
+TIMELINE_COST_WARN = 100
+# Cumulative budget guard: warn + skip remaining timeline fetches above this point
+TIMELINE_CUMULATIVE_WARN = 4500
+
+PR_TIMELINE_QUERY = """
+query($prId: ID!, $cursor: String) {
+  node(id: $prId) {
+    ... on PullRequest {
+      timelineItems(first: 100, after: $cursor, itemTypes: [
+        REVIEW_REQUESTED_EVENT,
+        PULL_REQUEST_REVIEW,
+        MERGED_EVENT,
+        CLOSED_EVENT,
+        LABELED_EVENT,
+        REFERENCED_EVENT
+      ]) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          __typename
+          ... on PullRequestReview { author { login } state submittedAt }
+          ... on ReviewRequestedEvent { actor { login } createdAt }
+          ... on MergedEvent { actor { login } createdAt }
+          ... on ClosedEvent { actor { login } createdAt }
+          ... on LabeledEvent { actor { login } createdAt label { name } }
+          ... on ReferencedEvent { actor { login } createdAt }
+        }
+      }
+    }
+  }
+  rateLimit { cost remaining }
+}
+"""
+
 
 class RetriesExhausted(Exception):
     pass
@@ -338,3 +373,71 @@ class GraphQLClient:
             # All other cases: preserve checkpoint for next-run resume
 
         return nodes
+
+    def fetch_pr_timeline(
+        self,
+        pr_node_id: str,
+        deadline_monotonic: float | None = None,
+        cumulative_cost: list[int] | None = None,
+    ) -> list[dict]:
+        """Fetch all timeline events for a PR, paginating if needed.
+
+        Returns list of raw event dicts. Raises CostBudgetExceeded if the
+        cumulative cost across all timeline queries in the run approaches the
+        hourly budget (TIMELINE_CUMULATIVE_WARN). If pr_node_id is not found
+        (node returns None), returns an empty list.
+
+        cumulative_cost: caller-supplied single-element list used as a mutable
+        integer accumulator. Pass [0] to enable cross-PR cost tracking.
+        """
+        nodes = self.paginate(
+            query=PR_TIMELINE_QUERY,
+            variables={"prId": pr_node_id, "cursor": None},
+            page_info_path=["data", "node", "timelineItems", "pageInfo"],
+            nodes_path=["data", "node", "timelineItems", "nodes"],
+            deadline_monotonic=deadline_monotonic,
+            cursor_var="cursor",
+        )
+
+        # Track cumulative cost from the last response (rateLimit is in each page body).
+        # We re-execute a small extra call to get cost when paginate() completes. Instead,
+        # we track it inline by wrapping execute(). Since paginate() already called execute(),
+        # we piggyback cost via a separate last-query cost read. For simplicity, we call
+        # a single extra non-paginated query only if cumulative tracking is requested.
+        # Actually: paginate() calls execute() which already logs cost per call. We track
+        # cumulative by reading rateLimit from each response. Since paginate() abstracts
+        # execute(), we do one more execute() call here only for cost — wasteful. Better:
+        # pass a cost callback. For now, use a single post-paginate cost probe only when
+        # cumulative_cost is provided.
+        if cumulative_cost is not None:
+            try:
+                probe = self.execute(
+                    "query { rateLimit { cost remaining } }",
+                    deadline_monotonic=deadline_monotonic,
+                )
+                rate = (probe.get("data") or {}).get("rateLimit") or {}
+                cost = rate.get("cost", 1)
+                remaining = rate.get("remaining", 5000)
+                cumulative_cost[0] += cost
+                if cost > TIMELINE_COST_WARN:
+                    print(
+                        f"WARNING: timeline query cost {cost} exceeds threshold {TIMELINE_COST_WARN}",
+                        file=sys.stderr,
+                    )
+                if remaining < 100:
+                    print(
+                        f"CRITICAL: rateLimit.remaining={remaining} — approaching rate limit",
+                        file=sys.stderr,
+                    )
+                if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+                    raise CostBudgetExceeded(
+                        f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
+                        "skipping remaining timeline fetches for this run"
+                    )
+            except CostBudgetExceeded:
+                raise
+            except Exception:
+                pass  # cost tracking failure is non-fatal
+
+        return nodes
+

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import sqlite3
 import sys
@@ -9,6 +10,8 @@ from collections.abc import Callable
 import httpx
 
 from pulse.ipv4 import apply_ipv4_patch
+
+logger = logging.getLogger(__name__)
 
 COST_WARN_THRESHOLD = 10
 COST_ABORT_THRESHOLD = 50
@@ -312,8 +315,10 @@ class GraphQLClient:
                 if on_page_response is not None:
                     try:
                         on_page_response(body)
+                    except PRNodeNotFound:
+                        raise  # null-node sentinel: stop pagination immediately
                     except Exception:
-                        pass  # callback failure must not interrupt pagination
+                        pass  # other callback failures must not interrupt pagination
 
                 try:
                     page_info: dict = body
@@ -347,7 +352,7 @@ class GraphQLClient:
 
                 variables[cursor_var] = end_cursor
 
-        except (RunDeadlineExceeded, RetriesExhausted, CostBudgetExceeded, RuntimeError):
+        except (RunDeadlineExceeded, RetriesExhausted, CostBudgetExceeded, RuntimeError, PRNodeNotFound):
             # Interrupted — save cursor so next run resumes instead of restarting from page 1
             if use_checkpoint and last_cursor:
                 try:
@@ -395,30 +400,43 @@ class GraphQLClient:
     ) -> list[dict]:
         """Fetch all timeline events for a PR, paginating if needed.
 
-        Returns list of raw event dicts. Raises CostBudgetExceeded if the
-        cumulative cost across all timeline queries in the run approaches the
-        hourly budget (TIMELINE_CUMULATIVE_WARN). If pr_node_id is not found
-        (node returns None), returns an empty list.
+        Returns list of raw event dicts. Raises CostBudgetExceeded (pre-fetch)
+        if cumulative cost is already >= TIMELINE_CUMULATIVE_WARN before this
+        call starts. If pr_node_id is not found (node returns None), raises
+        PRNodeNotFound.
 
         cumulative_cost: caller-supplied single-element list used as a mutable
         integer accumulator. Pass [0] to enable cross-PR cost tracking.
-        """
-        accumulated_cost = [0]
-        last_remaining = [5000]
-        node_not_found = [False]
 
+        Cost accounting invariants:
+        - Budget gate fires BEFORE any work; raises immediately if over budget.
+        - finally block ONLY accumulates cost; never raises (would mask paginate errors).
+        - If THIS call pushes over budget, a warning is logged but data is returned;
+          the NEXT call's pre-fetch gate will skip it.
+        """
+        # Pre-fetch gate: skip if already over budget
+        if cumulative_cost is not None and cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+            raise CostBudgetExceeded(
+                f"cumulative timeline cost {cumulative_cost[0]} already >= {TIMELINE_CUMULATIVE_WARN}; "
+                "skipping remaining timeline fetches for this run"
+            )
+
+        accumulated_cost = [0]
         def _on_page(resp: dict) -> None:
             data = resp.get("data") or {}
-            if data.get("node") is None and "node" in data:
-                node_not_found[0] = True
+            # Accumulate cost FIRST so null-node responses don't silently drop their cost.
             rate = data.get("rateLimit") or {}
             page_cost = rate.get("cost", 0)
             accumulated_cost[0] += page_cost
             remaining = rate.get("remaining")
-            if remaining is not None:
-                last_remaining[0] = remaining
+            if remaining is not None and remaining < 100:
+                logger.warning("GitHub rate limit remaining=%d — approaching limit", remaining)
+            # Check for null node AFTER cost accounting, BEFORE any timelineItems traversal.
+            # Raising PRNodeNotFound here causes paginate() to re-raise it (see except clause),
+            # which propagates to our try/finally below — cost already flushed above.
+            if data.get("node") is None and "node" in data:
+                raise PRNodeNotFound(f"PR node_id not found on GitHub: {pr_node_id}")
 
-        # try/finally ensures cost is flushed even if paginate() raises mid-walk
         try:
             nodes = self.paginate(
                 query=PR_TIMELINE_QUERY,
@@ -430,31 +448,22 @@ class GraphQLClient:
                 on_page_response=_on_page,
             )
         finally:
-            # Always flush accumulated cost, even if paginate() raised
+            # Pure accumulation only — NEVER raise from finally (would mask paginate exceptions)
             if cumulative_cost is not None:
                 cumulative_cost[0] += accumulated_cost[0]
-                if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
-                    raise CostBudgetExceeded(
-                        f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
-                        "skipping remaining timeline fetches for this run"
-                    )
 
-        if node_not_found[0]:
-            raise PRNodeNotFound(f"PR node_id not found on GitHub: {pr_node_id}")
+        # Post-fetch: warn if THIS call pushed us over budget (next call's gate will skip)
+        if cumulative_cost is not None and cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+            logger.warning(
+                "Cumulative timeline cost %d >= %d after this PR; next call will be skipped",
+                cumulative_cost[0], TIMELINE_CUMULATIVE_WARN,
+            )
 
-        if cumulative_cost is not None:
-            cost = accumulated_cost[0]
-            remaining = last_remaining[0]
-            if cost > TIMELINE_COST_WARN:
-                print(
-                    f"WARNING: timeline query cost {cost} exceeds threshold {TIMELINE_COST_WARN}",
-                    file=sys.stderr,
-                )
-            if remaining < 100:
-                print(
-                    f"CRITICAL: rateLimit.remaining={remaining} — approaching rate limit",
-                    file=sys.stderr,
-                )
+        if accumulated_cost[0] > TIMELINE_COST_WARN:
+            logger.warning(
+                "Timeline query cost %d exceeds per-PR threshold %d",
+                accumulated_cost[0], TIMELINE_COST_WARN,
+            )
 
         return nodes
 

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -418,15 +418,26 @@ class GraphQLClient:
             if remaining is not None:
                 last_remaining[0] = remaining
 
-        nodes = self.paginate(
-            query=PR_TIMELINE_QUERY,
-            variables={"prId": pr_node_id, "cursor": None},
-            page_info_path=["data", "node", "timelineItems", "pageInfo"],
-            nodes_path=["data", "node", "timelineItems", "nodes"],
-            deadline_monotonic=deadline_monotonic,
-            cursor_var="cursor",
-            on_page_response=_on_page,
-        )
+        # try/finally ensures cost is flushed even if paginate() raises mid-walk
+        try:
+            nodes = self.paginate(
+                query=PR_TIMELINE_QUERY,
+                variables={"prId": pr_node_id, "cursor": None},
+                page_info_path=["data", "node", "timelineItems", "pageInfo"],
+                nodes_path=["data", "node", "timelineItems", "nodes"],
+                deadline_monotonic=deadline_monotonic,
+                cursor_var="cursor",
+                on_page_response=_on_page,
+            )
+        finally:
+            # Always flush accumulated cost, even if paginate() raised
+            if cumulative_cost is not None:
+                cumulative_cost[0] += accumulated_cost[0]
+                if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+                    raise CostBudgetExceeded(
+                        f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
+                        "skipping remaining timeline fetches for this run"
+                    )
 
         if node_not_found[0]:
             raise PRNodeNotFound(f"PR node_id not found on GitHub: {pr_node_id}")
@@ -434,7 +445,6 @@ class GraphQLClient:
         if cumulative_cost is not None:
             cost = accumulated_cost[0]
             remaining = last_remaining[0]
-            cumulative_cost[0] += cost
             if cost > TIMELINE_COST_WARN:
                 print(
                     f"WARNING: timeline query cost {cost} exceeds threshold {TIMELINE_COST_WARN}",
@@ -444,11 +454,6 @@ class GraphQLClient:
                 print(
                     f"CRITICAL: rateLimit.remaining={remaining} — approaching rate limit",
                     file=sys.stderr,
-                )
-            if cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
-                raise CostBudgetExceeded(
-                    f"cumulative timeline cost {cumulative_cost[0]} >= {TIMELINE_CUMULATIVE_WARN}; "
-                    "skipping remaining timeline fetches for this run"
                 )
 
         return nodes

--- a/pulse/graphql.py
+++ b/pulse/graphql.py
@@ -6,6 +6,7 @@ import sqlite3
 import sys
 import time
 from collections.abc import Callable
+from datetime import datetime, timezone
 
 import httpx
 
@@ -21,6 +22,27 @@ DEFAULT_DEADLINE_SEC = int(os.environ.get("PULSE_RUN_DEADLINE_SEC", "1200"))
 TIMELINE_COST_WARN = 100
 # Cumulative budget guard: warn + skip remaining timeline fetches above this point
 TIMELINE_CUMULATIVE_WARN = 4500
+
+VULN_ALERTS_QUERY = """
+query($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    vulnerabilityAlerts(first: 100, after: $cursor, states: OPEN) {
+      totalCount
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        securityVulnerability {
+          severity
+          package { name ecosystem }
+          advisory { ghsaId publishedAt }
+        }
+        dependabotUpdate { pullRequest { number updatedAt } }
+        createdAt
+      }
+    }
+  }
+  rateLimit { cost remaining }
+}
+"""
 
 PR_TIMELINE_QUERY = """
 query($prId: ID!, $cursor: String) {
@@ -73,6 +95,11 @@ class CostBudgetExceeded(Exception):
 
 class PRNodeNotFound(Exception):
     """Raised when a PR node_id is not found on GitHub (data.node=null)."""
+    pass
+
+
+class ScopeMissing(Exception):
+    """Raised when the GitHub token lacks required scopes (e.g. security_events)."""
     pass
 
 
@@ -473,4 +500,107 @@ class GraphQLClient:
             )
 
         return nodes
+
+    @staticmethod
+    def _node_to_vuln_alert(node: dict) -> "VulnerabilityAlert":
+        from pulse.schema import VulnerabilityAlert
+        vuln = node["securityVulnerability"]
+        published = vuln["advisory"]["publishedAt"]  # ISO-8601
+        age_days = (
+            datetime.now(timezone.utc)
+            - datetime.fromisoformat(published.replace("Z", "+00:00"))
+        ).days
+        dep_pr = None
+        if node.get("dependabotUpdate") and node["dependabotUpdate"].get("pullRequest"):
+            dep_pr = node["dependabotUpdate"]["pullRequest"]["number"]
+        return VulnerabilityAlert(
+            severity=vuln["severity"],
+            ghsa_id=vuln["advisory"]["ghsaId"],
+            package_name=vuln["package"]["name"],
+            ecosystem=vuln["package"]["ecosystem"],
+            age_days=age_days,
+            dependabot_pr_number=dep_pr,
+        )
+
+    def fetch_vuln_alerts(
+        self,
+        owner: str,
+        name: str,
+        cumulative_cost: list[int] | None = None,
+    ) -> list["VulnerabilityAlert"]:
+        """Fetch all open vulnerability alerts for a repo, paginating if needed.
+
+        Returns list of VulnerabilityAlert objects, deduped by (ghsa_id, package_name).
+        Raises ScopeMissing if token lacks security_events scope.
+        Raises CostBudgetExceeded if cumulative cost gate fires before first fetch.
+        """
+        from pulse.schema import VulnerabilityAlert
+
+        # Pre-fetch gate: skip if already over budget (same pattern as fetch_pr_timeline)
+        if cumulative_cost is not None and cumulative_cost[0] >= TIMELINE_CUMULATIVE_WARN:
+            raise CostBudgetExceeded(
+                f"cumulative cost {cumulative_cost[0]} already >= {TIMELINE_CUMULATIVE_WARN}; "
+                "skipping vuln alerts fetch for this run"
+            )
+
+        accumulated_cost = [0]
+        # Mutable flag: on_page_response sets this when INSUFFICIENT_SCOPES detected.
+        # paginate() swallows all exceptions except PRNodeNotFound from on_page_response,
+        # so we signal via flag and raise after paginate() returns.
+        scope_missing_msg: list[str] = []
+
+        def _on_page(resp: dict) -> None:
+            data = resp.get("data") or {}
+            rate = data.get("rateLimit") or {}
+            page_cost = rate.get("cost", 0)
+            accumulated_cost[0] += page_cost
+            remaining = rate.get("remaining")
+            if remaining is not None and remaining < 100:
+                logger.warning(
+                    "GitHub rate limit remaining=%d — approaching limit", remaining
+                )
+            # Check for INSUFFICIENT_SCOPES error (flag — not raise, paginate() swallows it)
+            errors = resp.get("errors") or []
+            for err in errors:
+                if err.get("type") == "INSUFFICIENT_SCOPES":
+                    scope_missing_msg.append(
+                        f"Token lacks required scope for vulnerabilityAlerts: {err.get('message', '')}"
+                    )
+
+        try:
+            nodes = self.paginate(
+                query=VULN_ALERTS_QUERY,
+                variables={"owner": owner, "name": name, "cursor": None},
+                page_info_path=["data", "repository", "vulnerabilityAlerts", "pageInfo"],
+                nodes_path=["data", "repository", "vulnerabilityAlerts", "nodes"],
+                cursor_var="cursor",
+                on_page_response=_on_page,
+            )
+        except CostBudgetExceeded as e:
+            accumulated_cost[0] += getattr(e, "cost", 0)
+            raise
+        finally:
+            if cumulative_cost is not None:
+                cumulative_cost[0] += accumulated_cost[0]
+
+        # Raise ScopeMissing after paginate() completes if flag was set
+        if scope_missing_msg:
+            raise ScopeMissing(scope_missing_msg[0])
+
+        # Convert nodes to VulnerabilityAlert, dedup by (ghsa_id, package_name)
+        seen: set[tuple[str, str]] = set()
+        alerts: list[VulnerabilityAlert] = []
+        for node in nodes:
+            try:
+                alert = self._node_to_vuln_alert(node)
+            except (KeyError, TypeError) as e:
+                logger.warning("Failed to parse vuln alert node: %s", e)
+                continue
+            key = (alert.ghsa_id, alert.package_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            alerts.append(alert)
+
+        return alerts
 

--- a/pulse/migrate.py
+++ b/pulse/migrate.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import os
 import shutil
 import sqlite3
 from datetime import datetime, timezone
@@ -105,10 +107,13 @@ def run_migration(db_path: Path) -> str:
         ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
         backup_path = db_path.parent / f"pulse.db.pre-v1-{ts}"
 
+        # Create backup file with 0o600 from the start (atomic, no world-readable window)
+        backup_fd = os.open(str(backup_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        os.close(backup_fd)
         # Fix 5: SQLite-safe backup using built-in backup API (handles WAL mode correctly)
-        with sqlite3.connect(str(backup_path)) as backup_conn:
+        # Fix 3: contextlib.closing() ensures backup_conn is closed even if backup() raises
+        with contextlib.closing(sqlite3.connect(str(backup_path))) as backup_conn:
             conn.backup(backup_conn)
-        backup_path.chmod(0o600)
 
         # Fix 3: IF NOT EXISTS guards for ALTER TABLE
         # SQLite ALTER TABLE autocommits — with conn: does NOT roll back DDL.

--- a/pulse/migrate.py
+++ b/pulse/migrate.py
@@ -50,7 +50,7 @@ def run_migration(db_path: Path) -> str:
     4. Pre-migration integrity check
     5. Disk-space check (backup size × 2 ≤ free space, including WAL/SHM)
     6. Backup DB → pulse.db.pre-v1-<ISO-8601-microseconds>
-    7. ALTER TABLE — 3 new columns (upstream, vulnerability_alerts, review_events)
+    7. ALTER TABLE — 4 new columns (upstream, vulnerability_alerts, node_id, review_events)
     8. Post-migration integrity check
     9. PRAGMA user_version = 11
     10. Return "migrated"
@@ -118,12 +118,14 @@ def run_migration(db_path: Path) -> str:
         # Fix 3: IF NOT EXISTS guards for ALTER TABLE
         # SQLite ALTER TABLE autocommits — with conn: does NOT roll back DDL.
         # Check column existence first to make partial migration recovery safe.
-        # 3 new columns added: upstream, vulnerability_alerts, review_events.
+        # 4 new columns added: upstream, vulnerability_alerts, node_id, review_events.
         # schema_version already exists in v0 DDL (DEFAULT '1.0') — no ALTER needed.
         if not _column_exists(conn, "repos", "upstream"):
             conn.execute("ALTER TABLE repos ADD COLUMN upstream TEXT")
         if not _column_exists(conn, "repos", "vulnerability_alerts"):
             conn.execute("ALTER TABLE repos ADD COLUMN vulnerability_alerts TEXT")
+        if not _column_exists(conn, "prs", "node_id"):
+            conn.execute("ALTER TABLE prs ADD COLUMN node_id TEXT")
         if not _column_exists(conn, "prs", "review_events"):
             conn.execute("ALTER TABLE prs ADD COLUMN review_events TEXT")
 

--- a/pulse/migrate.py
+++ b/pulse/migrate.py
@@ -21,6 +21,19 @@ def _integrity_check(conn: sqlite3.Connection) -> bool:
     return result == "ok"
 
 
+def _verify_v0_schema_shape(conn: sqlite3.Connection) -> bool:
+    """Verify expected v0 tables exist (for user_version=0 DBs)."""
+    expected = {"snapshots", "repos", "prs", "issues", "releases"}
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    found = {r[0] for r in rows}
+    return expected.issubset(found)
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
 def run_migration(db_path: Path) -> str:
     """
     Idempotent v0→v1 migration.
@@ -29,16 +42,23 @@ def run_migration(db_path: Path) -> str:
     Raises RuntimeError with a clear message on any failure.
 
     Steps:
-    1. Open DB (read-only check of user_version)
-    2. If already v1 (user_version=11), return "no-op"
-    3. Pre-migration integrity check
-    4. Disk-space check (backup size × 2 ≤ free space)
-    5. Backup DB → pulse.db.pre-v1-<ISO-8601>
-    6. ALTER TABLE in single transaction
-    7. PRAGMA user_version = 11
+    1. Verify DB exists
+    2. Open DB (read-only check of user_version)
+    3. If already v1 (user_version=11), return "no-op"
+    4. Pre-migration integrity check
+    5. Disk-space check (backup size × 2 ≤ free space, including WAL/SHM)
+    6. Backup DB → pulse.db.pre-v1-<ISO-8601-microseconds>
+    7. ALTER TABLE with IF NOT EXISTS guards
     8. Post-migration integrity check
-    9. Return "migrated"
+    9. PRAGMA user_version = 11
+    10. Return "migrated"
     """
+    # Fix 8: refuse if pulse.db doesn't exist
+    if not db_path.exists():
+        raise RuntimeError(
+            f"pulse.db not found at {db_path} — run pulse --now first to create it"
+        )
+
     conn = sqlite3.connect(str(db_path))
     try:
         current_version = _get_user_version(conn)
@@ -47,10 +67,18 @@ def run_migration(db_path: Path) -> str:
         if current_version == _V1_USER_VERSION:
             return "no-op"
 
-        # Step 2b: unexpected version guard
-        if current_version != _V0_USER_VERSION:
+        # Fix 2: accept user_version=0 (pre-fix v0 DBs) OR user_version=10
+        if current_version == 0:
+            # Unversioned v0 DB — verify schema shape before proceeding
+            if not _verify_v0_schema_shape(conn):
+                raise RuntimeError(
+                    "user_version=0 but expected v0 tables not found — "
+                    "this does not look like a pulse v0 database"
+                )
+        elif current_version != _V0_USER_VERSION:
             raise RuntimeError(
-                f"unexpected user_version; expected {_V0_USER_VERSION} (v0), got {current_version}"
+                f"unexpected user_version; expected {_V0_USER_VERSION} (v0) or 0 (unversioned v0), "
+                f"got {current_version}"
             )
 
         # Step 3: pre-migration integrity check
@@ -59,47 +87,53 @@ def run_migration(db_path: Path) -> str:
                 "pre-migration integrity_check failed — refusing to migrate"
             )
 
-        # Step 4: disk-space check
+        # Fix 7: disk-space check includes WAL + SHM
         db_size = db_path.stat().st_size
+        wal_path = db_path.with_suffix(db_path.suffix + "-wal")
+        shm_path = db_path.with_suffix(db_path.suffix + "-shm")
+        wal_size = wal_path.stat().st_size if wal_path.exists() else 0
+        shm_size = shm_path.stat().st_size if shm_path.exists() else 0
+        total_size = db_size + wal_size + shm_size
         usage = shutil.disk_usage(db_path.parent)
-        if db_size * _SAFETY_MULTIPLIER > usage.free:
+        if total_size * _SAFETY_MULTIPLIER > usage.free:
             raise RuntimeError(
-                f"Insufficient disk space for backup: need {db_size * _SAFETY_MULTIPLIER:,} bytes "
-                f"(2× {db_size:,}), have {usage.free:,} free at {db_path.parent}"
+                f"Insufficient disk space for backup: need {total_size * _SAFETY_MULTIPLIER:,} bytes "
+                f"(2× {total_size:,}), have {usage.free:,} free at {db_path.parent}"
             )
 
-        # Step 5: backup
-        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        # Fix 6: microsecond uniqueness in backup filename
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
         backup_path = db_path.parent / f"pulse.db.pre-v1-{ts}"
-        shutil.copy2(db_path, backup_path)
+
+        # Fix 5: SQLite-safe backup using built-in backup API (handles WAL mode correctly)
+        with sqlite3.connect(str(backup_path)) as backup_conn:
+            conn.backup(backup_conn)
         backup_path.chmod(0o600)
 
-        # Step 6: ALTER TABLE in single transaction.
-        # schema_version already exists in the v0 DDL (DEFAULT '1.0'); skip if present.
-        def _existing_columns(table: str) -> set[str]:
-            rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
-            return {row[1] for row in rows}
+        # Fix 3: IF NOT EXISTS guards for ALTER TABLE
+        # SQLite ALTER TABLE autocommits — with conn: does NOT roll back DDL.
+        # Check column existence first to make partial migration recovery safe.
+        if not _column_exists(conn, "repos", "upstream"):
+            conn.execute("ALTER TABLE repos ADD COLUMN upstream TEXT")
+        if not _column_exists(conn, "repos", "vulnerability_alerts"):
+            conn.execute("ALTER TABLE repos ADD COLUMN vulnerability_alerts TEXT")
+        if not _column_exists(conn, "prs", "review_events"):
+            conn.execute("ALTER TABLE prs ADD COLUMN review_events TEXT")
+        # schema_version already exists in v0 DDL (DEFAULT '1.0'); skip if present
+        if not _column_exists(conn, "snapshots", "schema_version"):
+            conn.execute(
+                "ALTER TABLE snapshots ADD COLUMN schema_version TEXT DEFAULT '1.1'"
+            )
 
-        try:
-            with conn:
-                conn.execute("ALTER TABLE repos ADD COLUMN upstream TEXT")
-                conn.execute("ALTER TABLE repos ADD COLUMN vulnerability_alerts TEXT")
-                conn.execute("ALTER TABLE prs ADD COLUMN review_events TEXT")
-                if "schema_version" not in _existing_columns("snapshots"):
-                    conn.execute(
-                        "ALTER TABLE snapshots ADD COLUMN schema_version TEXT DEFAULT '1.1'"
-                    )
-        except Exception as e:
-            raise RuntimeError(f"ALTER TABLE failed: {e}") from e
-
-        # Step 7: PRAGMA user_version — must be OUTSIDE the transaction
-        conn.execute(f"PRAGMA user_version = {_V1_USER_VERSION}")
-
-        # Step 8: post-migration integrity check
+        # Fix 4: integrity_check BEFORE user_version bump
+        # If check fails, DB is NOT permanently tagged v1
         if not _integrity_check(conn):
             raise RuntimeError(
                 f"post-migration integrity_check failed — backup preserved at {backup_path}"
             )
+
+        # PRAGMA user_version must be OUTSIDE any transaction
+        conn.execute(f"PRAGMA user_version = {_V1_USER_VERSION}")
 
     finally:
         conn.close()

--- a/pulse/migrate.py
+++ b/pulse/migrate.py
@@ -48,7 +48,7 @@ def run_migration(db_path: Path) -> str:
     4. Pre-migration integrity check
     5. Disk-space check (backup size × 2 ≤ free space, including WAL/SHM)
     6. Backup DB → pulse.db.pre-v1-<ISO-8601-microseconds>
-    7. ALTER TABLE with IF NOT EXISTS guards
+    7. ALTER TABLE — 3 new columns (upstream, vulnerability_alerts, review_events)
     8. Post-migration integrity check
     9. PRAGMA user_version = 11
     10. Return "migrated"
@@ -113,17 +113,14 @@ def run_migration(db_path: Path) -> str:
         # Fix 3: IF NOT EXISTS guards for ALTER TABLE
         # SQLite ALTER TABLE autocommits — with conn: does NOT roll back DDL.
         # Check column existence first to make partial migration recovery safe.
+        # 3 new columns added: upstream, vulnerability_alerts, review_events.
+        # schema_version already exists in v0 DDL (DEFAULT '1.0') — no ALTER needed.
         if not _column_exists(conn, "repos", "upstream"):
             conn.execute("ALTER TABLE repos ADD COLUMN upstream TEXT")
         if not _column_exists(conn, "repos", "vulnerability_alerts"):
             conn.execute("ALTER TABLE repos ADD COLUMN vulnerability_alerts TEXT")
         if not _column_exists(conn, "prs", "review_events"):
             conn.execute("ALTER TABLE prs ADD COLUMN review_events TEXT")
-        # schema_version already exists in v0 DDL (DEFAULT '1.0'); skip if present
-        if not _column_exists(conn, "snapshots", "schema_version"):
-            conn.execute(
-                "ALTER TABLE snapshots ADD COLUMN schema_version TEXT DEFAULT '1.1'"
-            )
 
         # Fix 4: integrity_check BEFORE user_version bump
         # If check fails, DB is NOT permanently tagged v1

--- a/pulse/migrate.py
+++ b/pulse/migrate.py
@@ -1,0 +1,107 @@
+"""pulse/migrate.py — v0→v1 SQLite migration."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+_V0_USER_VERSION = 10
+_V1_USER_VERSION = 11
+_SAFETY_MULTIPLIER = 2  # backup size × 2 must fit in free space
+
+
+def _get_user_version(conn: sqlite3.Connection) -> int:
+    return conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+def _integrity_check(conn: sqlite3.Connection) -> bool:
+    result = conn.execute("PRAGMA integrity_check").fetchone()[0]
+    return result == "ok"
+
+
+def run_migration(db_path: Path) -> str:
+    """
+    Idempotent v0→v1 migration.
+
+    Returns a status string: "no-op" if already v1, "migrated" on success.
+    Raises RuntimeError with a clear message on any failure.
+
+    Steps:
+    1. Open DB (read-only check of user_version)
+    2. If already v1 (user_version=11), return "no-op"
+    3. Pre-migration integrity check
+    4. Disk-space check (backup size × 2 ≤ free space)
+    5. Backup DB → pulse.db.pre-v1-<ISO-8601>
+    6. ALTER TABLE in single transaction
+    7. PRAGMA user_version = 11
+    8. Post-migration integrity check
+    9. Return "migrated"
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        current_version = _get_user_version(conn)
+
+        # Step 2: idempotency gate
+        if current_version == _V1_USER_VERSION:
+            return "no-op"
+
+        # Step 2b: unexpected version guard
+        if current_version != _V0_USER_VERSION:
+            raise RuntimeError(
+                f"unexpected user_version; expected {_V0_USER_VERSION} (v0), got {current_version}"
+            )
+
+        # Step 3: pre-migration integrity check
+        if not _integrity_check(conn):
+            raise RuntimeError(
+                "pre-migration integrity_check failed — refusing to migrate"
+            )
+
+        # Step 4: disk-space check
+        db_size = db_path.stat().st_size
+        usage = shutil.disk_usage(db_path.parent)
+        if db_size * _SAFETY_MULTIPLIER > usage.free:
+            raise RuntimeError(
+                f"Insufficient disk space for backup: need {db_size * _SAFETY_MULTIPLIER:,} bytes "
+                f"(2× {db_size:,}), have {usage.free:,} free at {db_path.parent}"
+            )
+
+        # Step 5: backup
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        backup_path = db_path.parent / f"pulse.db.pre-v1-{ts}"
+        shutil.copy2(db_path, backup_path)
+        backup_path.chmod(0o600)
+
+        # Step 6: ALTER TABLE in single transaction.
+        # schema_version already exists in the v0 DDL (DEFAULT '1.0'); skip if present.
+        def _existing_columns(table: str) -> set[str]:
+            rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+            return {row[1] for row in rows}
+
+        try:
+            with conn:
+                conn.execute("ALTER TABLE repos ADD COLUMN upstream TEXT")
+                conn.execute("ALTER TABLE repos ADD COLUMN vulnerability_alerts TEXT")
+                conn.execute("ALTER TABLE prs ADD COLUMN review_events TEXT")
+                if "schema_version" not in _existing_columns("snapshots"):
+                    conn.execute(
+                        "ALTER TABLE snapshots ADD COLUMN schema_version TEXT DEFAULT '1.1'"
+                    )
+        except Exception as e:
+            raise RuntimeError(f"ALTER TABLE failed: {e}") from e
+
+        # Step 7: PRAGMA user_version — must be OUTSIDE the transaction
+        conn.execute(f"PRAGMA user_version = {_V1_USER_VERSION}")
+
+        # Step 8: post-migration integrity check
+        if not _integrity_check(conn):
+            raise RuntimeError(
+                f"post-migration integrity_check failed — backup preserved at {backup_path}"
+            )
+
+    finally:
+        conn.close()
+
+    return "migrated"

--- a/pulse/migrate.py
+++ b/pulse/migrate.py
@@ -128,6 +128,8 @@ def run_migration(db_path: Path) -> str:
             conn.execute("ALTER TABLE prs ADD COLUMN node_id TEXT")
         if not _column_exists(conn, "prs", "review_events"):
             conn.execute("ALTER TABLE prs ADD COLUMN review_events TEXT")
+        if not _column_exists(conn, "snapshots", "reviewer_activity_7d"):
+            conn.execute("ALTER TABLE snapshots ADD COLUMN reviewer_activity_7d TEXT")
 
         # Fix 4: integrity_check BEFORE user_version bump
         # If check fails, DB is NOT permanently tagged v1

--- a/pulse/rollup.py
+++ b/pulse/rollup.py
@@ -81,17 +81,17 @@ def compute_reviewer_activity_7d(conn: sqlite3.Connection) -> dict:
         if bucket not in buckets:
             buckets[bucket] = {"total": 0, "approved": 0, "change_requested": 0, "commented": 0, "dismissed": 0}
         b = buckets[bucket]
-        b["total"] += 1
-        if state == "APPROVED":
-            b["approved"] += 1
-        elif state == "CHANGES_REQUESTED":
-            b["change_requested"] += 1
-        elif event_type == "IssueComment" or (state in ("COMMENTED", None) and event_type == "PULL_REQUEST_REVIEW"):
-            b["commented"] += 1
-        elif state == "DISMISSED":
-            b["dismissed"] += 1
-        elif event_type in ("REVIEW_REQUESTED_EVENT", "MERGED_EVENT", "CLOSED_EVENT", "LABELED_EVENT", "REFERENCED_EVENT"):
-            pass  # non-review events — count in total but not in sub-buckets
+        if event_type in ("PULL_REQUEST_REVIEW", "IssueComment"):
+            b["total"] += 1
+            if state == "APPROVED":
+                b["approved"] += 1
+            elif state == "CHANGES_REQUESTED":
+                b["change_requested"] += 1
+            elif event_type == "IssueComment" or state in ("COMMENTED", None):
+                b["commented"] += 1
+            elif state == "DISMISSED":
+                b["dismissed"] += 1
+        # non-review timeline events (MERGED_EVENT, etc.) — not counted in any bucket
 
     return buckets
 

--- a/pulse/rollup.py
+++ b/pulse/rollup.py
@@ -1,0 +1,114 @@
+"""pulse/rollup.py — 7-day reviewer activity rollup."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import sqlite3
+import time
+from datetime import datetime, timezone
+
+from pulse.snapshot import DEPENDABOT_AUTHORS, RENOVATE_AUTHORS
+
+COPILOT_AUTHORS = frozenset({"Copilot", "copilot-pull-request-reviewer[bot]"})
+GEMINI_CA_AUTHORS = frozenset({"gemini-code-assist", "gemini-code-assist[bot]"})
+CLAUDE_SUBAGENT_AUTHORS = frozenset({
+    "claude-subagent", "claude-code", "anthropic-claude", "claude-ai"
+    # PR Review Toolkit bot patterns — extend as needed
+})
+
+_log = logging.getLogger(__name__)
+
+
+def classify_author(author: str) -> str:
+    """Return bucket key for a reviewer author login."""
+    if author in COPILOT_AUTHORS:
+        return "copilot"
+    if author in GEMINI_CA_AUTHORS:
+        return "gemini-ca"
+    if author in CLAUDE_SUBAGENT_AUTHORS:
+        return "claude-subagent"
+    if author in DEPENDABOT_AUTHORS:
+        return "dependabot"
+    if author in RENOVATE_AUTHORS:
+        return "renovate"
+    return f"human:{author}"
+
+
+def _seven_days_ago_iso() -> str:
+    return (datetime.now(timezone.utc) - dt.timedelta(days=7)).isoformat().replace("+00:00", "Z")
+
+
+def compute_reviewer_activity_7d(conn: sqlite3.Connection) -> dict:
+    """
+    Query prs.review_events JSON blobs across last 7 days via json_each.
+    Returns bucketed reviewer activity dict.
+    Uses SQLite JSON1 extension — no Python-side deserialization for filtering.
+    """
+    seven_days_ago = _seven_days_ago_iso()
+
+    start = time.monotonic()
+
+    rows = conn.execute("""
+        SELECT
+            json_extract(evt.value, '$.author') as author,
+            json_extract(evt.value, '$.state') as state,
+            json_extract(evt.value, '$.type') as type
+        FROM snapshots s
+        JOIN repos r ON r.snapshot_id = s.id
+        JOIN prs p ON p.repo_id = r.id,
+        json_each(p.review_events) AS evt
+        WHERE s.captured_at_utc >= ?
+          AND s.capture_status != 'failed'
+          AND p.review_events IS NOT NULL
+          AND p.review_events != 'null'
+    """, (seven_days_ago,)).fetchall()
+
+    elapsed = time.monotonic() - start
+    if elapsed > 2.0:
+        _log.warning("reviewer_activity_7d rollup took %.2fs — consider indexing", elapsed)
+
+    buckets: dict[str, dict] = {}
+
+    for author, state, event_type in rows:
+        if not author:
+            continue
+        bucket = classify_author(author)
+        if bucket not in buckets:
+            buckets[bucket] = {"total": 0, "approved": 0, "change_requested": 0, "commented": 0, "dismissed": 0}
+        b = buckets[bucket]
+        b["total"] += 1
+        if state == "APPROVED":
+            b["approved"] += 1
+        elif state == "CHANGES_REQUESTED":
+            b["change_requested"] += 1
+        elif state in ("COMMENTED", None) and event_type == "PULL_REQUEST_REVIEW":
+            b["commented"] += 1
+        elif state == "DISMISSED":
+            b["dismissed"] += 1
+        elif event_type in ("REVIEW_REQUESTED_EVENT", "MERGED_EVENT", "CLOSED_EVENT", "LABELED_EVENT", "REFERENCED_EVENT"):
+            pass  # non-review events — count in total but not in sub-buckets
+
+    return buckets
+
+
+def count_snapshots_in_last_7d(conn: sqlite3.Connection) -> int:
+    """Count completed snapshots within the last 7 days."""
+    seven_days_ago = _seven_days_ago_iso()
+    row = conn.execute("""
+        SELECT count(*) FROM snapshots
+        WHERE captured_at_utc >= ? AND capture_status != 'failed'
+    """, (seven_days_ago,)).fetchone()
+    return row[0] if row else 0
+
+
+def oldest_snapshot_in_7d(conn: sqlite3.Connection) -> str | None:
+    """Return captured_at_utc of oldest snapshot in 7-day window."""
+    seven_days_ago = _seven_days_ago_iso()
+    row = conn.execute("""
+        SELECT captured_at_utc FROM snapshots
+        WHERE captured_at_utc >= ? AND capture_status != 'failed'
+        ORDER BY captured_at_utc ASC LIMIT 1
+    """, (seven_days_ago,)).fetchone()
+    return row[0] if row else None

--- a/pulse/rollup.py
+++ b/pulse/rollup.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime as dt
-import json
 import logging
 import sqlite3
 import time
@@ -55,15 +54,19 @@ def compute_reviewer_activity_7d(conn: sqlite3.Connection) -> dict:
             json_extract(evt.value, '$.author') as author,
             json_extract(evt.value, '$.state') as state,
             json_extract(evt.value, '$.type') as type
-        FROM snapshots s
-        JOIN repos r ON r.snapshot_id = s.id
+        FROM (
+            SELECT MAX(id) as snap_id FROM snapshots
+            WHERE capture_status != 'failed'
+              AND captured_at_utc >= ?
+        ) latest
+        JOIN repos r ON r.snapshot_id = latest.snap_id
         JOIN prs p ON p.repo_id = r.id,
         json_each(p.review_events) AS evt
-        WHERE s.captured_at_utc >= ?
-          AND s.capture_status != 'failed'
-          AND p.review_events IS NOT NULL
+        WHERE p.review_events IS NOT NULL
           AND p.review_events != 'null'
-    """, (seven_days_ago,)).fetchall()
+          AND (json_extract(evt.value, '$.submitted_at') >= ?
+               OR json_extract(evt.value, '$.submitted_at') IS NULL)
+    """, (seven_days_ago, seven_days_ago)).fetchall()
 
     elapsed = time.monotonic() - start
     if elapsed > 2.0:
@@ -83,7 +86,7 @@ def compute_reviewer_activity_7d(conn: sqlite3.Connection) -> dict:
             b["approved"] += 1
         elif state == "CHANGES_REQUESTED":
             b["change_requested"] += 1
-        elif state in ("COMMENTED", None) and event_type == "PULL_REQUEST_REVIEW":
+        elif event_type == "IssueComment" or (state in ("COMMENTED", None) and event_type == "PULL_REQUEST_REVIEW"):
             b["commented"] += 1
         elif state == "DISMISSED":
             b["dismissed"] += 1

--- a/pulse/schema.py
+++ b/pulse/schema.py
@@ -4,6 +4,16 @@ from dataclasses import dataclass, field
 
 
 @dataclass
+class ReviewEvent:
+    type: str  # __typename: PULL_REQUEST_REVIEW, REVIEW_REQUESTED_EVENT, MERGED_EVENT, CLOSED_EVENT, LABELED_EVENT, REFERENCED_EVENT
+    author: str | None
+    state: str | None = None      # for PULL_REQUEST_REVIEW: APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED
+    label: str | None = None      # for LABELED_EVENT
+    submitted_at: str | None = None
+    created_at: str | None = None
+
+
+@dataclass
 class FieldStatus:
     status: str  # success | partial | disabled | failed
     error_note: str | None = None
@@ -38,6 +48,7 @@ class PRData:
     is_renovate: bool
     hours_idle: float | None
     stalled: bool
+    node_id: str | None = None
     review_events: list | None = None
 
 

--- a/pulse/schema.py
+++ b/pulse/schema.py
@@ -22,6 +22,8 @@ class RepoData:
     parent_is_deleted: bool
     capture_status: str
     field_statuses: dict[str, FieldStatus] = field(default_factory=dict)
+    upstream: dict | None = None
+    vulnerability_alerts: list | None = None
 
 
 @dataclass
@@ -36,6 +38,7 @@ class PRData:
     is_renovate: bool
     hours_idle: float | None
     stalled: bool
+    review_events: list | None = None
 
 
 @dataclass

--- a/pulse/schema.py
+++ b/pulse/schema.py
@@ -2,6 +2,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from pydantic import BaseModel
+
+
+class UpstreamStatus(BaseModel):
+    status: str  # "success" | "parent_unavailable" | "failed" | "not_fork"
+    commits_behind: int | None = None
+    commits_ahead: int | None = None
+    recent_upstream_releases: list[dict] | None = None
+    error_note: str | None = None
+
+
+class VulnerabilityAlert(BaseModel):
+    severity: str           # CRITICAL | HIGH | MODERATE | LOW (verbatim from GitHub)
+    ghsa_id: str
+    package_name: str
+    ecosystem: str
+    age_days: int
+    dependabot_pr_number: int | None = None
+
 
 @dataclass
 class ReviewEvent:
@@ -34,6 +53,7 @@ class RepoData:
     field_statuses: dict[str, FieldStatus] = field(default_factory=dict)
     upstream: dict | None = None
     vulnerability_alerts: list | None = None
+    parent_default_branch: str | None = None
 
 
 @dataclass

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -381,18 +381,33 @@ def _capture_pr_timelines(
                     error_note=f"timeline capture failed for PR #{pr.number}: {str(e)[:100]}",
                 )
 
-    if skipped_no_node_id == len(prs) and prs:
-        logging.getLogger(__name__).warning(
-            "All %d PRs for repo_id=%s lack node_id; timeline capture skipped entirely",
-            len(prs), repo_id,
-        )
+    if skipped_no_node_id > 0 and prs:
+        if skipped_no_node_id == len(prs):
+            logging.getLogger(__name__).warning(
+                "All %d PRs for repo_id=%s lack node_id; timeline capture skipped entirely",
+                len(prs), repo_id,
+            )
+        else:
+            logging.getLogger(__name__).warning(
+                "%d/%d PRs for repo_id=%s lack node_id; their timelines skipped",
+                skipped_no_node_id, len(prs), repo_id,
+            )
+        # Treat as partial — we skipped work we should have done
+        any_failure = True
 
     if budget_exceeded:
         repo.field_statuses["review_events"] = FieldStatus(
             status="partial",
             error_note=f"skipped: cumulative cost approached {TIMELINE_CUMULATIVE_WARN}/hr limit",
         )
-    elif not any_failure:
+    elif any_failure:
+        # Set partial if not already set by the per-PR exception handler above
+        if "review_events" not in repo.field_statuses:
+            repo.field_statuses["review_events"] = FieldStatus(
+                status="partial",
+                error_note=f"all {len(prs)} PRs lack node_id; timeline capture skipped",
+            )
+    else:
         repo.field_statuses["review_events"] = FieldStatus(status="success")
 
 

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -10,7 +10,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from pulse.config import PulseConfig
-from pulse.graphql import CostBudgetExceeded, GraphQLClient, PRNodeNotFound, TIMELINE_CUMULATIVE_WARN
+from pulse.gh_rest import GHRestClient
+from pulse.graphql import CostBudgetExceeded, GraphQLClient, PRNodeNotFound, ScopeMissing, TIMELINE_CUMULATIVE_WARN
 from pulse.schema import FieldStatus, IssueData, PRData, ReleaseData, RepoData, ReviewEvent
 from pulse.storage import atomic_write_json
 
@@ -34,7 +35,7 @@ query($org: String!, $cursor: String) {
         hasIssuesEnabled
         pullRequests(first: 1) { totalCount }
         issues(first: 1) { totalCount }
-        parent { owner { login } name }
+        parent { owner { login } name defaultBranchRef { name } }
       }
     }
   }
@@ -281,6 +282,115 @@ def _capture_releases(
     except Exception as e:
         return [], FieldStatus(status="failed", error_note=str(e)[:200])
 
+
+
+def _capture_upstream(
+    rest_client: GHRestClient,
+    repo: RepoData,
+    conn: sqlite3.Connection,
+    repo_id: int,
+) -> None:
+    """Capture fork upstream compare delta and store as JSON in repos.upstream.
+
+    Only runs if repo.is_fork == True and repo.parent is available.
+    Gracefully degrades: exceptions stored as failed status, never abort caller.
+    """
+    if not repo.is_fork:
+        return
+    if not repo.parent_owner or not repo.parent_name:
+        return
+
+    fork_branch = repo.default_branch
+    parent_branch = repo.parent_default_branch if hasattr(repo, "parent_default_branch") else None
+
+    if not fork_branch or not parent_branch:
+        upstream_blob = {
+            "status": "failed",
+            "error_note": "missing default_branch for fork or parent",
+        }
+        repo.field_statuses["upstream"] = FieldStatus(
+            status="failed", error_note=upstream_blob["error_note"]
+        )
+    else:
+        try:
+            result = rest_client.compare_fork_upstream(
+                fork_owner=repo.org,
+                fork_repo=repo.name,
+                fork_default_branch=fork_branch,
+                parent_owner=repo.parent_owner,
+                parent_default_branch=parent_branch,
+            )
+            upstream_blob = result
+            repo.field_statuses["upstream"] = FieldStatus(
+                status=result.get("status", "success")
+                if result.get("status") in ("success", "parent_unavailable")
+                else "failed"
+            )
+        except Exception as e:
+            upstream_blob = {"status": "failed", "error_note": str(e)[:200]}
+            repo.field_statuses["upstream"] = FieldStatus(
+                status="failed", error_note=str(e)[:200]
+            )
+
+    try:
+        with conn:
+            conn.execute(
+                "UPDATE repos SET upstream=? WHERE id=?",
+                (json.dumps(upstream_blob), repo_id),
+            )
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            "Failed to write upstream for repo_id=%s: %s", repo_id, e
+        )
+
+
+def _capture_vuln_alerts(
+    graphql_client: GraphQLClient,
+    repo: RepoData,
+    conn: sqlite3.Connection,
+    repo_id: int,
+    cumulative_cost: list[int] | None = None,
+) -> None:
+    """Capture open vulnerability alerts and store as JSON in repos.vulnerability_alerts.
+
+    Handles ScopeMissing with a LOUD field_status alert. Other exceptions stored as failed.
+    Gracefully degrades: never aborts caller.
+    """
+    alerts_blob: list | dict
+    try:
+        alerts = graphql_client.fetch_vuln_alerts(
+            owner=repo.org,
+            name=repo.name,
+            cumulative_cost=cumulative_cost,
+        )
+        alerts_blob = [a.model_dump() for a in alerts]
+        repo.field_statuses["vulnerability_alerts"] = FieldStatus(status="success")
+    except ScopeMissing as e:
+        alerts_blob = {"status": "scope_missing", "error_note": str(e)[:200]}
+        repo.field_statuses["vulnerability_alerts"] = FieldStatus(
+            status="scope_missing",
+            error_note=f"ALERT: token lacks security_events scope — vuln alerts unavailable: {str(e)[:150]}",
+        )
+        logging.getLogger(__name__).warning(
+            "SCOPE MISSING: vulnerability alerts require security_events scope on token (repo=%s/%s): %s",
+            repo.org, repo.name, e,
+        )
+    except Exception as e:
+        alerts_blob = {"status": "failed", "error_note": str(e)[:200]}
+        repo.field_statuses["vulnerability_alerts"] = FieldStatus(
+            status="failed", error_note=str(e)[:200]
+        )
+
+    try:
+        with conn:
+            conn.execute(
+                "UPDATE repos SET vulnerability_alerts=? WHERE id=?",
+                (json.dumps(alerts_blob), repo_id),
+            )
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            "Failed to write vulnerability_alerts for repo_id=%s: %s", repo_id, e
+        )
 
 
 def _event_to_review_event(node: dict) -> ReviewEvent:
@@ -652,6 +762,7 @@ def run_snapshot(
     gql: GraphQLClient,
     deadline: float | None,
     output_dir: Path | None = None,
+    rest_client: GHRestClient | None = None,
 ) -> str:
     """Run one full snapshot, persist to SQLite, write current/prev JSON. Returns snapshot_id."""
     start_time = time.monotonic()
@@ -684,6 +795,15 @@ def run_snapshot(
         captured_at_et=captured_at_et,
         orgs_queried=orgs_queried,
     )
+
+    # Set up REST client (caller may pass one in for testing; otherwise create from env)
+    _rest_client_owner = rest_client is None
+    if rest_client is None:
+        import os as _os
+        _token = _os.environ.get("GH_TOKEN") or _os.environ.get("GITHUB_TOKEN")
+        if _token:
+            rest_client = GHRestClient(token=_token)
+    _rest_client = rest_client
 
     org_errors: list[str] = []
     orgs_succeeded = 0
@@ -729,6 +849,7 @@ def run_snapshot(
             parent = node.get("parent") or {}
             parent_owner = (parent.get("owner") or {}).get("login")
             parent_name = parent.get("name")
+            parent_default_branch = (parent.get("defaultBranchRef") or {}).get("name")
 
             has_issues = bool(node.get("hasIssuesEnabled", True))
             default_branch_ref = node.get("defaultBranchRef") or {}
@@ -745,6 +866,7 @@ def run_snapshot(
                 parent_is_deleted=False,
                 capture_status="success",
                 field_statuses={},
+                parent_default_branch=parent_default_branch,
             )
 
             # Capture PRs
@@ -814,7 +936,31 @@ def run_snapshot(
                             repos_partial += 1
                             repo.capture_status = "partial"
                             counted_as = "partial"
-                # Update field_statuses in the DB row
+
+            # Capture fork upstream delta (REST, graceful)
+            if repo_id is not None and _rest_client is not None:
+                _capture_upstream(_rest_client, repo, db_conn, repo_id)
+                up_status = repo.field_statuses.get("upstream")
+                if up_status and up_status.status in ("partial", "failed"):
+                    if counted_as == "success":
+                        repos_succeeded -= 1
+                        repos_partial += 1
+                        repo.capture_status = "partial"
+                        counted_as = "partial"
+
+            # Capture vulnerability alerts (GraphQL, graceful)
+            if repo_id is not None:
+                _capture_vuln_alerts(gql, repo, db_conn, repo_id, cumulative_timeline_cost)
+                va_status = repo.field_statuses.get("vulnerability_alerts")
+                if va_status and va_status.status in ("partial", "failed", "scope_missing"):
+                    if counted_as == "success":
+                        repos_succeeded -= 1
+                        repos_partial += 1
+                        repo.capture_status = "partial"
+                        counted_as = "partial"
+
+            # Update field_statuses in the DB row after all captures
+            if repo_id is not None:
                 try:
                     field_statuses_json = json.dumps(
                         {k: {"status": v.status, "error_note": v.error_note}
@@ -863,5 +1009,12 @@ def run_snapshot(
 
     # Prune old snapshots
     _prune_old_snapshots(db_conn, cfg.defaults.history_days)
+
+    # Close REST client if we created it
+    if _rest_client_owner and _rest_client is not None:
+        try:
+            _rest_client.close()
+        except Exception:
+            pass
 
     return snapshot_id

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -999,6 +999,21 @@ def run_snapshot(
         capture_status=snapshot_capture_status,
     )
 
+    # Compute and cache 7-day reviewer activity rollup
+    # Local import to avoid circular dependency (rollup imports DEPENDABOT_AUTHORS from this module)
+    try:
+        from pulse.rollup import compute_reviewer_activity_7d
+        rollup = compute_reviewer_activity_7d(db_conn)
+        with db_conn:
+            db_conn.execute(
+                "UPDATE snapshots SET reviewer_activity_7d=? WHERE id=?",
+                (json.dumps(rollup), snapshot_id),
+            )
+    except Exception as e:
+        logging.getLogger(__name__).warning(
+            "reviewer_activity_7d rollup failed for snapshot %s: %s", snapshot_id, e
+        )
+
     # Write JSON artifacts
     if output_dir is not None:
         current_data = _build_current_json(db_conn, snapshot_id)

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -624,6 +624,7 @@ def _build_current_json(
                         "is_dependabot": bool(r["is_dependabot"]),
                         "is_renovate": bool(r["is_renovate"]),
                         "stalled": bool(r["stalled"]),
+                        "review_events": json.loads(r["review_events"]) if r["review_events"] else None,
                     }
                     for r in pr_rows
                 ],

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -405,7 +405,7 @@ def _capture_pr_timelines(
         if "review_events" not in repo.field_statuses:
             repo.field_statuses["review_events"] = FieldStatus(
                 status="partial",
-                error_note=f"all {len(prs)} PRs lack node_id; timeline capture skipped",
+                error_note=f"{skipped_no_node_id}/{len(prs)} PRs lack node_id; timeline capture skipped",
             )
     else:
         repo.field_statuses["review_events"] = FieldStatus(status="success")

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -9,8 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from pulse.config import PulseConfig
-from pulse.graphql import GraphQLClient
-from pulse.schema import FieldStatus, IssueData, PRData, ReleaseData, RepoData
+from pulse.graphql import CostBudgetExceeded, GraphQLClient, TIMELINE_CUMULATIVE_WARN
+from pulse.schema import FieldStatus, IssueData, PRData, ReleaseData, RepoData, ReviewEvent
 from pulse.storage import atomic_write_json
 
 DEPENDABOT_AUTHORS = {"dependabot[bot]", "dependabot-preview[bot]", "app/dependabot"}
@@ -48,6 +48,7 @@ query($org: String!, $repo: String!, $first: Int!, $cursor: String) {
       totalCount
       pageInfo { hasNextPage endCursor }
       nodes {
+        id
         number title
         author { login }
         createdAt updatedAt
@@ -160,6 +161,7 @@ def _capture_prs(
                     is_renovate=author_login in RENOVATE_AUTHORS if author_login else False,
                     hours_idle=idle,
                     stalled=idle is not None and idle > stall_hours,
+                    node_id=node.get("id"),
                 )
             )
 
@@ -280,6 +282,107 @@ def _capture_releases(
 
 
 
+def _event_to_review_event(node: dict) -> ReviewEvent:
+    """Convert a raw timeline event node to a ReviewEvent."""
+    typename = node.get("__typename", "")
+    actor = (node.get("actor") or {}).get("login") or None
+    author_obj = (node.get("author") or {}).get("login") or None
+    # PullRequestReview uses 'author', all others use 'actor'
+    author = author_obj if typename == "PullRequestReview" else actor
+    label_obj = node.get("label") or {}
+    return ReviewEvent(
+        type=typename,
+        author=author,
+        state=node.get("state") if typename == "PullRequestReview" else None,
+        label=label_obj.get("name") if typename == "LabeledEvent" else None,
+        submitted_at=node.get("submittedAt") if typename == "PullRequestReview" else None,
+        created_at=node.get("createdAt") if typename != "PullRequestReview" else None,
+    )
+
+
+def _capture_pr_timelines(
+    gql: GraphQLClient,
+    conn: sqlite3.Connection,
+    repo_id: int,
+    prs: list[PRData],
+    repo: RepoData,
+    deadline: float | None,
+    cumulative_cost: list[int],
+) -> None:
+    """Fetch timeline events for each PR and write review_events JSON to the prs table.
+
+    Graceful degradation: per-PR failures set review_events=NULL and update
+    repo.field_statuses['review_events'] to partial. CostBudgetExceeded causes
+    remaining PRs to be skipped (review_events stays NULL).
+    """
+    budget_exceeded = False
+    any_failure = False
+
+    for pr in prs:
+        if budget_exceeded:
+            # Skip remaining — leave review_events NULL
+            continue
+
+        if not pr.node_id:
+            # No node_id available — skip silently
+            continue
+
+        try:
+            raw_events = gql.fetch_pr_timeline(
+                pr.node_id,
+                deadline_monotonic=deadline,
+                cumulative_cost=cumulative_cost,
+            )
+            events = [_event_to_review_event(n) for n in raw_events if n.get("__typename")]
+            review_json = json.dumps(
+                [
+                    {
+                        "type": e.type,
+                        "author": e.author,
+                        "state": e.state,
+                        "label": e.label,
+                        "submitted_at": e.submitted_at,
+                        "created_at": e.created_at,
+                    }
+                    for e in events
+                ]
+            )
+            with conn:
+                conn.execute(
+                    "UPDATE prs SET review_events=? WHERE repo_id=? AND number=?",
+                    (review_json, repo_id, pr.number),
+                )
+
+        except CostBudgetExceeded as e:
+            import sys as _sys
+            print(f"WARNING: {e} — skipping remaining PR timelines", file=_sys.stderr)
+            budget_exceeded = True
+            any_failure = True
+
+        except Exception as e:
+            import sys as _sys
+            print(
+                f"WARNING: timeline capture failed for PR #{pr.number}: {e}",
+                file=_sys.stderr,
+            )
+            any_failure = True
+            # Leave review_events=NULL for this PR
+            existing = repo.field_statuses.get("review_events")
+            if existing is None or existing.status == "success":
+                repo.field_statuses["review_events"] = FieldStatus(
+                    status="partial",
+                    error_note=f"timeline capture failed for PR #{pr.number}: {str(e)[:100]}",
+                )
+
+    if budget_exceeded:
+        repo.field_statuses["review_events"] = FieldStatus(
+            status="partial",
+            error_note=f"skipped: cumulative cost approached {TIMELINE_CUMULATIVE_WARN}/hr limit",
+        )
+    elif not any_failure:
+        repo.field_statuses["review_events"] = FieldStatus(status="success")
+
+
 def _insert_snapshot_placeholder(
     db_conn: sqlite3.Connection,
     snapshot_id: str,
@@ -333,7 +436,7 @@ def _persist_repo(
     prs: list[PRData],
     issues: list[IssueData],
     releases: list[ReleaseData],
-) -> None:
+) -> int:
     field_statuses_json = json.dumps(
         {k: {"status": v.status, "error_note": v.error_note} for k, v in repo.field_statuses.items()}
     )
@@ -366,8 +469,9 @@ def _persist_repo(
                 """
                 INSERT OR REPLACE INTO prs
                   (repo_id, number, title, author, created_at, updated_at,
-                   is_draft, is_dependabot, is_renovate, hours_idle, stalled)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   is_draft, is_dependabot, is_renovate, hours_idle, stalled,
+                   node_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     repo_id,
@@ -381,6 +485,7 @@ def _persist_repo(
                     int(pr.is_renovate),
                     pr.hours_idle,
                     int(pr.stalled),
+                    pr.node_id,
                 ),
             )
 
@@ -421,6 +526,7 @@ def _persist_repo(
                 ),
             )
 
+    return repo_id
 
 
 def _prune_old_snapshots(
@@ -552,6 +658,8 @@ def run_snapshot(
 
     org_errors: list[str] = []
     orgs_succeeded = 0
+    # Cumulative rateLimit.cost tracker across all timeline queries in this run
+    cumulative_timeline_cost: list[int] = [0]
     for org_name, org_config in cfg.orgs.items():
         # Enumerate repos
         try:
@@ -652,7 +760,7 @@ def run_snapshot(
 
             # Persist to SQLite
             try:
-                _persist_repo(db_conn, snapshot_id, repo, prs, issues, releases)
+                repo_id = _persist_repo(db_conn, snapshot_id, repo, prs, issues, releases)
             except Exception as e:
                 click.echo(f"ERROR: failed to persist {org_name}/{repo_name}: {e}", err=True)
                 repos_failed += 1
@@ -660,6 +768,36 @@ def run_snapshot(
                     repos_partial -= 1
                 else:
                     repos_succeeded -= 1
+                continue
+
+            # Capture PR timelines (after persist so we have repo_id)
+            if repo_id is not None and prs:
+                _capture_pr_timelines(
+                    gql, db_conn, repo_id, prs, repo,
+                    deadline, cumulative_timeline_cost,
+                )
+                # Re-evaluate repo status after timeline capture
+                if "review_events" in repo.field_statuses:
+                    rev_status = repo.field_statuses["review_events"]
+                    if rev_status.status in ("partial", "failed"):
+                        if counted_as == "success":
+                            repos_succeeded -= 1
+                            repos_partial += 1
+                            repo.capture_status = "partial"
+                            counted_as = "partial"
+                # Update field_statuses in the DB row
+                try:
+                    field_statuses_json = json.dumps(
+                        {k: {"status": v.status, "error_note": v.error_note}
+                         for k, v in repo.field_statuses.items()}
+                    )
+                    with db_conn:
+                        db_conn.execute(
+                            "UPDATE repos SET field_statuses=?, capture_status=? WHERE id=?",
+                            (field_statuses_json, repo.capture_status, repo_id),
+                        )
+                except Exception as e:
+                    click.echo(f"WARNING: failed to update field_statuses for {org_name}/{repo_name}: {e}", err=True)
 
     duration_ms = int((time.monotonic() - start_time) * 1000)
 

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import time
 
@@ -9,7 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from pulse.config import PulseConfig
-from pulse.graphql import CostBudgetExceeded, GraphQLClient, TIMELINE_CUMULATIVE_WARN
+from pulse.graphql import CostBudgetExceeded, GraphQLClient, PRNodeNotFound, TIMELINE_CUMULATIVE_WARN
 from pulse.schema import FieldStatus, IssueData, PRData, ReleaseData, RepoData, ReviewEvent
 from pulse.storage import atomic_write_json
 
@@ -317,6 +318,7 @@ def _capture_pr_timelines(
     """
     budget_exceeded = False
     any_failure = False
+    skipped_no_node_id = 0
 
     for pr in prs:
         if budget_exceeded:
@@ -325,6 +327,7 @@ def _capture_pr_timelines(
 
         if not pr.node_id:
             # No node_id available — skip silently
+            skipped_no_node_id += 1
             continue
 
         try:
@@ -353,6 +356,10 @@ def _capture_pr_timelines(
                     (review_json, repo_id, pr.number),
                 )
 
+        except PRNodeNotFound:
+            # Node not found on GitHub — leave review_events NULL silently (not a failure)
+            pass
+
         except CostBudgetExceeded as e:
             import sys as _sys
             print(f"WARNING: {e} — skipping remaining PR timelines", file=_sys.stderr)
@@ -373,6 +380,12 @@ def _capture_pr_timelines(
                     status="partial",
                     error_note=f"timeline capture failed for PR #{pr.number}: {str(e)[:100]}",
                 )
+
+    if skipped_no_node_id == len(prs) and prs:
+        logging.getLogger(__name__).warning(
+            "All %d PRs for repo_id=%s lack node_id; timeline capture skipped entirely",
+            len(prs), repo_id,
+        )
 
     if budget_exceeded:
         repo.field_statuses["review_events"] = FieldStatus(

--- a/pulse/snapshot.py
+++ b/pulse/snapshot.py
@@ -301,7 +301,7 @@ def _capture_upstream(
         return
 
     fork_branch = repo.default_branch
-    parent_branch = repo.parent_default_branch if hasattr(repo, "parent_default_branch") else None
+    parent_branch = repo.parent_default_branch
 
     if not fork_branch or not parent_branch:
         upstream_blob = {
@@ -374,6 +374,11 @@ def _capture_vuln_alerts(
         logging.getLogger(__name__).warning(
             "SCOPE MISSING: vulnerability alerts require security_events scope on token (repo=%s/%s): %s",
             repo.org, repo.name, e,
+        )
+    except CostBudgetExceeded:
+        alerts_blob = {"status": "partial", "error_note": "skipped: cumulative cost budget reached"}
+        repo.field_statuses["vulnerability_alerts"] = FieldStatus(
+            status="partial", error_note="skipped: cumulative cost budget reached"
         )
     except Exception as e:
         alerts_blob = {"status": "failed", "error_note": str(e)[:200]}
@@ -727,6 +732,8 @@ def _build_current_json(
                 "parent_is_deleted": bool(repo_row["parent_is_deleted"]),
                 "capture_status": repo_row["capture_status"],
                 "field_statuses": json.loads(repo_row["field_statuses"] or "{}"),
+                "upstream": json.loads(repo_row["upstream"]) if repo_row["upstream"] else None,
+                "vulnerability_alerts": json.loads(repo_row["vulnerability_alerts"]) if repo_row["vulnerability_alerts"] else None,
                 "prs": [
                     {
                         **dict(r),

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -133,7 +133,8 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 repos_failed INTEGER NOT NULL DEFAULT 0,
                 repos_partial INTEGER NOT NULL DEFAULT 0,
                 schema_version TEXT NOT NULL DEFAULT '1.0',
-                capture_status TEXT NOT NULL DEFAULT 'success'
+                capture_status TEXT NOT NULL DEFAULT 'success',
+                reviewer_activity_7d TEXT   -- JSON blob: {bucket: {total, approved, change_requested, commented, dismissed}}
             )
         """)
         conn.execute("""

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -213,9 +213,12 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 -- repo is TEXT (not FK) so pagination state survives snapshot deletion/pruning
             )
         """)
-    # Set user_version=10 to mark this as a known v0 schema.
+    # Set user_version=10 to mark this as a known v0 schema, but only on a
+    # fresh DB (current_version=0). Prevents downgrading an already-migrated DB.
     # Must run OUTSIDE the transaction (DDL auto-commits in SQLite).
-    conn.execute("PRAGMA user_version = 10")
+    current_version = conn.execute("PRAGMA user_version").fetchone()[0]
+    if current_version == 0:
+        conn.execute("PRAGMA user_version = 10")
 
 
 def atomic_write_json(path: Path, data: dict) -> None:

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -149,7 +149,9 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 parent_name TEXT,
                 parent_is_deleted INTEGER NOT NULL DEFAULT 0,
                 capture_status TEXT NOT NULL DEFAULT 'success',
-                field_statuses TEXT
+                field_statuses TEXT,
+                upstream TEXT,
+                vulnerability_alerts TEXT
             )
         """)
         conn.execute("""

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -213,6 +213,9 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 -- repo is TEXT (not FK) so pagination state survives snapshot deletion/pruning
             )
         """)
+    # Set user_version=10 to mark this as a known v0 schema.
+    # Must run OUTSIDE the transaction (DDL auto-commits in SQLite).
+    conn.execute("PRAGMA user_version = 10")
 
 
 def atomic_write_json(path: Path, data: dict) -> None:

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -97,7 +97,13 @@ def open_db(path: Path) -> sqlite3.Connection:
             if any(k in msg for k in ("malformed", "corrupt", "not a database", "disk image")):
                 raise DBCorrupt(f"integrity_check raised exception (corrupt db): {e}") from e
             raise DBSetupError(f"integrity_check failed (env error): {e}") from e
+        tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        fresh = not tables
         create_schema(conn)
+        if fresh:
+            conn.execute("PRAGMA user_version = 11")  # fresh v1 install
         return conn
     except DBCorrupt:
         conn.close()
@@ -215,13 +221,6 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 -- repo is TEXT (not FK) so pagination state survives snapshot deletion/pruning
             )
         """)
-    # Set user_version=11 to mark this as a v1 schema on fresh installs, but only on a
-    # fresh DB (current_version=0). Prevents downgrading an already-migrated DB.
-    # Fresh installs include all v1 columns, so stamping 11 avoids a no-op migration run.
-    # Must run OUTSIDE the transaction (DDL auto-commits in SQLite).
-    current_version = conn.execute("PRAGMA user_version").fetchone()[0]
-    if current_version == 0:
-        conn.execute("PRAGMA user_version = 11")
 
 
 def atomic_write_json(path: Path, data: dict) -> None:

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -215,12 +215,13 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 -- repo is TEXT (not FK) so pagination state survives snapshot deletion/pruning
             )
         """)
-    # Set user_version=10 to mark this as a known v0 schema, but only on a
+    # Set user_version=11 to mark this as a v1 schema on fresh installs, but only on a
     # fresh DB (current_version=0). Prevents downgrading an already-migrated DB.
+    # Fresh installs include all v1 columns, so stamping 11 avoids a no-op migration run.
     # Must run OUTSIDE the transaction (DDL auto-commits in SQLite).
     current_version = conn.execute("PRAGMA user_version").fetchone()[0]
     if current_version == 0:
-        conn.execute("PRAGMA user_version = 10")
+        conn.execute("PRAGMA user_version = 11")
 
 
 def atomic_write_json(path: Path, data: dict) -> None:

--- a/pulse/storage.py
+++ b/pulse/storage.py
@@ -160,6 +160,8 @@ def create_schema(conn: sqlite3.Connection) -> None:
                 is_renovate INTEGER NOT NULL DEFAULT 0,
                 hours_idle REAL,
                 stalled INTEGER NOT NULL DEFAULT 0,
+                node_id TEXT,
+                review_events TEXT,
                 UNIQUE(repo_id, number)
             )
         """)

--- a/tests/test_gh_rest.py
+++ b/tests/test_gh_rest.py
@@ -1,0 +1,188 @@
+"""tests/test_gh_rest.py — GHRestClient tests for fork upstream compare."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from pulse.gh_rest import GHRestClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_rest_response(
+    status_code: int,
+    body: dict | None = None,
+    text: str = "",
+    headers: dict | None = None,
+) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = body or {}
+    resp.text = text or str(body or {})
+    resp.headers = headers or {}
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=MagicMock(), response=resp
+        )
+    return resp
+
+
+def _make_client() -> GHRestClient:
+    with patch("pulse.gh_rest.apply_ipv4_patch"):
+        return GHRestClient(token="test-token", force_ipv4=False)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Happy path — fork compare returns commits_behind and commits_ahead
+# ---------------------------------------------------------------------------
+
+def test_compare_fork_upstream_happy_path() -> None:
+    """Happy path: compare endpoint returns behind_by and ahead_by correctly."""
+    compare_body = {
+        "status": "diverged",
+        "behind_by": 5,
+        "ahead_by": 2,
+        "commits": [],
+    }
+    resp = _make_rest_response(200, compare_body)
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        result = client.compare_fork_upstream(
+            fork_owner="myorg",
+            fork_repo="myfork",
+            fork_default_branch="develop",
+            parent_owner="upstream-org",
+            parent_default_branch="main",
+        )
+
+    assert result["status"] == "success"
+    assert result["commits_behind"] == 5
+    assert result["commits_ahead"] == 2
+    assert "recent_upstream_releases" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 2: 404 on deleted/missing upstream → parent_unavailable, no crash
+# ---------------------------------------------------------------------------
+
+def test_compare_fork_upstream_404_parent_unavailable() -> None:
+    """404 response → status=parent_unavailable, no exception raised."""
+    resp = _make_rest_response(
+        404, text="Not Found: upstream repo deleted"
+    )
+    # 404 should NOT trigger raise_for_status
+    resp.raise_for_status.side_effect = None
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        result = client.compare_fork_upstream(
+            fork_owner="myorg",
+            fork_repo="myfork",
+            fork_default_branch="main",
+            parent_owner="deleted-org",
+            parent_default_branch="main",
+        )
+
+    assert result["status"] == "parent_unavailable"
+    assert "error_note" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Branch names from captured data appear in the request URL — not hardcoded "main"
+# ---------------------------------------------------------------------------
+
+def test_compare_uses_captured_branch_names_not_hardcoded() -> None:
+    """Branch names from caller args appear in the request URL, not hardcoded 'main'."""
+    compare_body = {"behind_by": 0, "ahead_by": 0, "status": "identical"}
+    resp = _make_rest_response(200, compare_body)
+
+    client = _make_client()
+    captured_requests: list[httpx.Request] = []
+
+    def fake_send(request: httpx.Request, **kwargs):
+        captured_requests.append(request)
+        return resp
+
+    with patch.object(client._client, "send", side_effect=fake_send):
+        client.compare_fork_upstream(
+            fork_owner="myorg",
+            fork_repo="myfork",
+            fork_default_branch="feature-branch",
+            parent_owner="upstream",
+            parent_default_branch="trunk",
+        )
+
+    assert len(captured_requests) == 1
+    url = str(captured_requests[0].url)
+    assert "feature-branch" in url, f"fork branch not in URL: {url}"
+    assert "trunk" in url, f"parent branch not in URL: {url}"
+    # Confirm 'main' is NOT hardcoded in this request (neither branch is 'main')
+    # The URL structure: compare/{parent}:{parent_branch}...{fork}:{fork_branch}
+    assert "upstream:trunk" in url
+    assert "myorg:feature-branch" in url
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Rate limit header warning when remaining < 10
+# ---------------------------------------------------------------------------
+
+def test_ratelimit_warning_when_remaining_low(caplog) -> None:
+    """Logger warning emitted when x-ratelimit-remaining < 10."""
+    import logging
+
+    compare_body = {"behind_by": 1, "ahead_by": 0, "status": "behind"}
+    resp = _make_rest_response(
+        200, compare_body, headers={"x-ratelimit-remaining": "3"}
+    )
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        with caplog.at_level(logging.WARNING, logger="pulse.gh_rest"):
+            client.compare_fork_upstream(
+                fork_owner="o", fork_repo="r",
+                fork_default_branch="main",
+                parent_owner="upstream", parent_default_branch="main",
+            )
+
+    assert any("rate limit" in rec.message.lower() or "remaining" in rec.message.lower()
+                for rec in caplog.records), \
+        f"Expected rate limit warning, got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Non-404 HTTP errors (401, 403) raise an exception
+# ---------------------------------------------------------------------------
+
+def test_compare_fork_upstream_401_raises() -> None:
+    """401 Unauthorized triggers raise_for_status → exception propagates."""
+    resp = _make_rest_response(401, text="Unauthorized")
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        with pytest.raises(httpx.HTTPStatusError):
+            client.compare_fork_upstream(
+                fork_owner="o", fork_repo="r",
+                fork_default_branch="main",
+                parent_owner="upstream", parent_default_branch="main",
+            )
+
+
+def test_compare_fork_upstream_403_raises() -> None:
+    """403 Forbidden triggers raise_for_status → exception propagates."""
+    resp = _make_rest_response(403, text="Forbidden")
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        with pytest.raises(httpx.HTTPStatusError):
+            client.compare_fork_upstream(
+                fork_owner="o", fork_repo="r",
+                fork_default_branch="main",
+                parent_owner="upstream", parent_default_branch="main",
+            )

--- a/tests/test_graphql_timeline.py
+++ b/tests/test_graphql_timeline.py
@@ -1,0 +1,460 @@
+"""tests/test_graphql_timeline.py — PR timeline collection tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from pulse.graphql import (
+    CostBudgetExceeded,
+    GraphQLClient,
+    PR_TIMELINE_QUERY,
+    TIMELINE_CUMULATIVE_WARN,
+)
+from pulse.schema import PRData, ReviewEvent
+from pulse.snapshot import _capture_pr_timelines, _event_to_review_event
+from pulse.storage import create_schema
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_response(status_code: int, body: dict, headers: dict | None = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = body
+    resp.text = str(body)
+    resp.headers = headers or {}
+    return resp
+
+
+def _make_client(force_ipv4: bool = False) -> GraphQLClient:
+    with patch("pulse.graphql.apply_ipv4_patch"):
+        return GraphQLClient(token="test-token", force_ipv4=force_ipv4)
+
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    create_schema(conn)
+    return conn
+
+
+def _insert_repo_and_pr(
+    conn: sqlite3.Connection,
+    pr_number: int = 1,
+    node_id: str = "PR_abc123",
+    repo_id: int | None = None,
+) -> tuple[int, int]:
+    """Insert snapshot+repo (idempotent) and a PR row. Returns (repo_id, pr_rowid).
+
+    Pass repo_id to reuse an existing repo row instead of inserting a new one.
+    """
+    with conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO snapshots (id, captured_at_utc, captured_at_et, orgs_queried)"
+            " VALUES ('snap1', '2026-01-01T00:00:00Z', '2026-01-01 00:00 ET', '[]')"
+        )
+        if repo_id is None:
+            cur = conn.execute(
+                "INSERT INTO repos (snapshot_id, org, name, capture_status)"
+                " VALUES ('snap1', 'org', 'repo', 'success')"
+            )
+            repo_id = cur.lastrowid
+        cur2 = conn.execute(
+            "INSERT INTO prs (repo_id, number, title, stalled, node_id)"
+            " VALUES (?, ?, 'PR title', 0, ?)",
+            (repo_id, pr_number, node_id),
+        )
+    return repo_id, cur2.lastrowid
+
+
+def _timeline_body(
+    nodes: list[dict],
+    has_next_page: bool = False,
+    end_cursor: str | None = None,
+    cost: int = 1,
+    remaining: int = 4999,
+) -> dict:
+    return {
+        "data": {
+            "node": {
+                "timelineItems": {
+                    "totalCount": len(nodes),
+                    "pageInfo": {"hasNextPage": has_next_page, "endCursor": end_cursor},
+                    "nodes": nodes,
+                }
+            },
+            "rateLimit": {"cost": cost, "remaining": remaining},
+        }
+    }
+
+
+def _ratelimit_probe_body(cost: int = 1, remaining: int = 4999) -> dict:
+    return {"data": {"rateLimit": {"cost": cost, "remaining": remaining}}}
+
+
+def _sample_review_node() -> dict:
+    return {
+        "__typename": "PullRequestReview",
+        "author": {"login": "alice"},
+        "state": "APPROVED",
+        "submittedAt": "2026-01-02T10:00:00Z",
+    }
+
+
+def _sample_requested_node() -> dict:
+    return {
+        "__typename": "ReviewRequestedEvent",
+        "actor": {"login": "bob"},
+        "createdAt": "2026-01-02T09:00:00Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Single-page timeline (≤100 events), captured in one query
+# ---------------------------------------------------------------------------
+
+def test_single_page_timeline() -> None:
+    """Single page (2 events) — captured in one fetch_pr_timeline call."""
+    nodes = [_sample_review_node(), _sample_requested_node()]
+    timeline_resp = _make_response(200, _timeline_body(nodes))
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+
+    client = _make_client()
+    cumulative = [0]
+
+    with patch.object(client._client, "send", side_effect=[timeline_resp, probe_resp]):
+        result = client.fetch_pr_timeline("PR_abc", cumulative_cost=cumulative)
+
+    assert len(result) == 2
+    assert result[0]["__typename"] == "PullRequestReview"
+    assert result[1]["__typename"] == "ReviewRequestedEvent"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Multi-page timeline (>100 events) — pagination followed, events concatenated
+# ---------------------------------------------------------------------------
+
+def test_multi_page_timeline_concatenated() -> None:
+    """Timeline spanning 2 pages — both pages fetched, all events returned."""
+    page1_node = _sample_review_node()
+    page2_node = _sample_requested_node()
+
+    page1_resp = _make_response(200, _timeline_body(
+        [page1_node], has_next_page=True, end_cursor="cursor-p1"
+    ))
+    page2_resp = _make_response(200, _timeline_body(
+        [page2_node], has_next_page=False
+    ))
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+
+    client = _make_client()
+    call_count = 0
+
+    def fake_send(request: httpx.Request, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return page1_resp
+        elif call_count == 2:
+            return page2_resp
+        else:
+            return probe_resp
+
+    with patch.object(client._client, "send", side_effect=fake_send):
+        result = client.fetch_pr_timeline("PR_abc", cumulative_cost=[0])
+
+    assert len(result) == 2
+    assert result[0]["__typename"] == "PullRequestReview"
+    assert result[1]["__typename"] == "ReviewRequestedEvent"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: itemTypes filter — lower cost when filter present
+# ---------------------------------------------------------------------------
+
+def test_itemtypes_filter_reduces_cost() -> None:
+    """Filtered query returns lower cost than hypothetical unfiltered response."""
+    # Simulated: filtered = cost 1, unfiltered = cost 10 (we assert filtered < unfiltered)
+    filtered_cost = 1
+    unfiltered_cost = 10
+
+    filtered_body = _timeline_body([_sample_review_node()], cost=filtered_cost)
+    unfiltered_body = _timeline_body(
+        [_sample_review_node()] * 10, cost=unfiltered_cost
+    )
+
+    filtered_resp = _make_response(200, filtered_body)
+    probe_resp = _make_response(200, _ratelimit_probe_body(cost=filtered_cost))
+
+    client = _make_client()
+
+    with patch.object(client._client, "send", side_effect=[filtered_resp, probe_resp]):
+        client.fetch_pr_timeline("PR_abc", cumulative_cost=[0])
+
+    # Verify PR_TIMELINE_QUERY contains itemTypes filter
+    assert "itemTypes" in PR_TIMELINE_QUERY
+    assert "PULL_REQUEST_REVIEW" in PR_TIMELINE_QUERY
+    assert "MERGED_EVENT" in PR_TIMELINE_QUERY
+
+    # Assert cost advantage: filtered < unfiltered
+    assert filtered_cost < unfiltered_cost
+
+
+# ---------------------------------------------------------------------------
+# Test 4: JSON blob queryable via json_extract in SQLite
+# ---------------------------------------------------------------------------
+
+def test_review_events_json_queryable_in_sqlite() -> None:
+    """review_events written as JSON blob is queryable via json_extract."""
+    conn = _make_db()
+    repo_id, _ = _insert_repo_and_pr(conn, pr_number=1, node_id="PR_node1")
+
+    events = [
+        {"type": "PullRequestReview", "author": "alice", "state": "APPROVED",
+         "label": None, "submitted_at": "2026-01-02T10:00:00Z", "created_at": None},
+        {"type": "ReviewRequestedEvent", "author": "bob", "state": None,
+         "label": None, "submitted_at": None, "created_at": "2026-01-02T09:00:00Z"},
+    ]
+    review_json = json.dumps(events)
+    with conn:
+        conn.execute(
+            "UPDATE prs SET review_events=? WHERE repo_id=? AND number=1",
+            (review_json, repo_id),
+        )
+
+    row = conn.execute(
+        "SELECT json_extract(review_events, '$[0].type') AS first_type FROM prs WHERE repo_id=?",
+        (repo_id,),
+    ).fetchone()
+    assert row is not None
+    assert row["first_type"] == "PullRequestReview"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Pagination resume — cursor correctly resumes mid-walk
+# ---------------------------------------------------------------------------
+
+def test_pagination_resume_with_cursor() -> None:
+    """Second call with a cursor starts from where first left off."""
+    page2_node = {"__typename": "MergedEvent", "actor": {"login": "carol"}, "createdAt": "2026-01-03T00:00:00Z"}
+
+    # Only one page from cursor position
+    page2_resp = _make_response(200, _timeline_body([page2_node], has_next_page=False))
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+
+    client = _make_client()
+    captured_vars: list[dict] = []
+
+    def fake_send(request: httpx.Request, **kwargs):
+        import json as _json
+        body = _json.loads(request.content)
+        captured_vars.append(body.get("variables", {}))
+        if len(captured_vars) == 1:
+            return page2_resp
+        return probe_resp
+
+    with patch.object(client._client, "send", side_effect=fake_send):
+        result = client.fetch_pr_timeline("PR_abc", cumulative_cost=[0])
+
+    assert len(result) == 1
+    assert result[0]["__typename"] == "MergedEvent"
+    # The first call should have used prId=PR_abc
+    assert captured_vars[0].get("prId") == "PR_abc"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Partial-capture failure — one PR fails, others still captured
+# ---------------------------------------------------------------------------
+
+def test_partial_capture_failure_continues() -> None:
+    """One PR timeline failure sets its review_events=NULL; other PRs still captured."""
+    conn = _make_db()
+    repo_id, _ = _insert_repo_and_pr(conn, pr_number=1, node_id="PR_fail")
+    _insert_repo_and_pr(conn, pr_number=2, node_id="PR_ok", repo_id=repo_id)
+
+    prs = [
+        PRData(number=1, title="PR 1", author="a", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id="PR_fail"),
+        PRData(number=2, title="PR 2", author="b", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id="PR_ok"),
+    ]
+
+    ok_events = [_sample_review_node()]
+    ok_body = _timeline_body(ok_events)
+    ok_resp = _make_response(200, ok_body)
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+
+    client = _make_client()
+    call_count = 0
+
+    def fake_send(request: httpx.Request, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        import json as _json
+        body = _json.loads(request.content)
+        variables = body.get("variables", {})
+        pr_id = variables.get("prId", "")
+        if pr_id == "PR_fail":
+            raise httpx.NetworkError("simulated failure")
+        return ok_resp if "prId" in variables else probe_resp
+
+    from pulse.schema import FieldStatus, RepoData
+    repo = RepoData(org="o", name="r", default_branch="main", is_fork=False,
+                    is_archived=False, has_issues_enabled=True, parent_owner=None,
+                    parent_name=None, parent_is_deleted=False, capture_status="success")
+
+    with patch.object(client._client, "send", side_effect=fake_send), \
+         patch("pulse.graphql.time.sleep"):
+        _capture_pr_timelines(client, conn, repo_id, prs, repo, None, [0])
+
+    pr1 = conn.execute("SELECT review_events FROM prs WHERE repo_id=? AND number=1", (repo_id,)).fetchone()
+    pr2 = conn.execute("SELECT review_events FROM prs WHERE repo_id=? AND number=2", (repo_id,)).fetchone()
+
+    # PR 1 failed — review_events should be NULL
+    assert pr1["review_events"] is None
+    # PR 2 succeeded — should have JSON
+    assert pr2["review_events"] is not None
+    parsed = json.loads(pr2["review_events"])
+    assert isinstance(parsed, list)
+    assert len(parsed) > 0
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Empty timeline — PR with 0 events → review_events = '[]', not NULL
+# ---------------------------------------------------------------------------
+
+def test_empty_timeline_stores_empty_list() -> None:
+    """PR with 0 timeline events → review_events = '[]', not NULL."""
+    conn = _make_db()
+    repo_id, _ = _insert_repo_and_pr(conn, pr_number=1, node_id="PR_empty")
+
+    prs = [
+        PRData(number=1, title="PR 1", author="a", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id="PR_empty"),
+    ]
+
+    empty_body = _timeline_body([])
+    empty_resp = _make_response(200, empty_body)
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+
+    client = _make_client()
+    call_count = 0
+
+    def fake_send(request: httpx.Request, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return empty_resp if call_count == 1 else probe_resp
+
+    from pulse.schema import RepoData
+    repo = RepoData(org="o", name="r", default_branch="main", is_fork=False,
+                    is_archived=False, has_issues_enabled=True, parent_owner=None,
+                    parent_name=None, parent_is_deleted=False, capture_status="success")
+
+    with patch.object(client._client, "send", side_effect=fake_send):
+        _capture_pr_timelines(client, conn, repo_id, prs, repo, None, [0])
+
+    pr = conn.execute("SELECT review_events FROM prs WHERE repo_id=? AND number=1", (repo_id,)).fetchone()
+    assert pr["review_events"] is not None
+    assert json.loads(pr["review_events"]) == []
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Orphan PR (node ID not found in GitHub) — graceful degradation, no crash
+# ---------------------------------------------------------------------------
+
+def test_orphan_pr_node_id_not_found() -> None:
+    """PR node ID returns None from GitHub (node not found) — graceful, no crash."""
+    conn = _make_db()
+    repo_id, _ = _insert_repo_and_pr(conn, pr_number=1, node_id="PR_orphan")
+
+    prs = [
+        PRData(number=1, title="Orphan PR", author="a", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id="PR_orphan"),
+    ]
+
+    # GitHub returns node=null when node ID is not found
+    orphan_body = {
+        "data": {
+            "node": None,
+            "rateLimit": {"cost": 1, "remaining": 4999},
+        }
+    }
+    orphan_resp = _make_response(200, orphan_body)
+    probe_resp = _make_response(200, _ratelimit_probe_body())
+    call_count = 0
+
+    def fake_send(request: httpx.Request, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return orphan_resp if call_count == 1 else probe_resp
+
+    client = _make_client()
+
+    from pulse.schema import RepoData
+    repo = RepoData(org="o", name="r", default_branch="main", is_fork=False,
+                    is_archived=False, has_issues_enabled=True, parent_owner=None,
+                    parent_name=None, parent_is_deleted=False, capture_status="success")
+
+    # Must not crash
+    with patch.object(client._client, "send", side_effect=fake_send):
+        _capture_pr_timelines(client, conn, repo_id, prs, repo, None, [0])
+
+    pr = conn.execute("SELECT review_events FROM prs WHERE repo_id=? AND number=1", (repo_id,)).fetchone()
+    # Node not found → path traversal returns [] → stored as '[]'
+    assert pr is not None
+    # Either empty list (graceful) or NULL (failure path) — either is acceptable, no crash
+    if pr["review_events"] is not None:
+        parsed = json.loads(pr["review_events"])
+        assert isinstance(parsed, list)
+
+
+# ---------------------------------------------------------------------------
+# Test 9 (bonus): _event_to_review_event correctly maps all typename fields
+# ---------------------------------------------------------------------------
+
+def test_event_to_review_event_mapping() -> None:
+    """_event_to_review_event correctly extracts fields for each __typename."""
+    review = _event_to_review_event({
+        "__typename": "PullRequestReview",
+        "author": {"login": "alice"},
+        "state": "APPROVED",
+        "submittedAt": "2026-01-02T10:00:00Z",
+    })
+    assert review.type == "PullRequestReview"
+    assert review.author == "alice"
+    assert review.state == "APPROVED"
+    assert review.submitted_at == "2026-01-02T10:00:00Z"
+    assert review.created_at is None
+
+    labeled = _event_to_review_event({
+        "__typename": "LabeledEvent",
+        "actor": {"login": "bot"},
+        "createdAt": "2026-01-02T11:00:00Z",
+        "label": {"name": "bug"},
+    })
+    assert labeled.type == "LabeledEvent"
+    assert labeled.author == "bot"
+    assert labeled.label == "bug"
+    assert labeled.state is None
+    assert labeled.submitted_at is None
+    assert labeled.created_at == "2026-01-02T11:00:00Z"
+
+    merged = _event_to_review_event({
+        "__typename": "MergedEvent",
+        "actor": {"login": "carol"},
+        "createdAt": "2026-01-03T00:00:00Z",
+    })
+    assert merged.type == "MergedEvent"
+    assert merged.label is None

--- a/tests/test_graphql_timeline.py
+++ b/tests/test_graphql_timeline.py
@@ -456,3 +456,55 @@ def test_event_to_review_event_mapping() -> None:
     })
     assert merged.type == "MergedEvent"
     assert merged.label is None
+
+
+# ---------------------------------------------------------------------------
+# Test 10: Pre-fetch gate — CostBudgetExceeded raised before any HTTP call
+# ---------------------------------------------------------------------------
+
+def test_pre_fetch_gate_skips_without_http_call() -> None:
+    """Budget already exhausted: fetch_pr_timeline raises before making any HTTP request."""
+    client = _make_client()
+    from unittest.mock import patch
+    with patch.object(client._client, "send") as mock_send:
+        with pytest.raises(CostBudgetExceeded):
+            client.fetch_pr_timeline("PR_abc123", cumulative_cost=[TIMELINE_CUMULATIVE_WARN])
+    mock_send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 11: All PRs missing node_id → review_events field_status = "partial"
+# ---------------------------------------------------------------------------
+
+def test_all_prs_missing_node_id_sets_partial_status() -> None:
+    """When every PR in a repo lacks node_id, review_events status should be 'partial'."""
+    from pulse.schema import FieldStatus, RepoData
+
+    conn = _make_db()
+    repo_id, _ = _insert_repo_and_pr(conn, pr_number=1, node_id=None)
+    _insert_repo_and_pr(conn, pr_number=2, node_id=None, repo_id=repo_id)
+
+    prs = [
+        PRData(number=1, title="PR 1", author="a", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id=None),
+        PRData(number=2, title="PR 2", author="b", created_at=None, updated_at=None,
+               is_draft=False, is_dependabot=False, is_renovate=False,
+               hours_idle=None, stalled=False, node_id=None),
+    ]
+
+    client = _make_client()
+    repo = RepoData(
+        org="o", name="r", default_branch="main", is_fork=False,
+        is_archived=False, has_issues_enabled=True, parent_owner=None,
+        parent_name=None, parent_is_deleted=False, capture_status="success",
+    )
+
+    # No HTTP calls should be made — all PRs skipped due to missing node_id
+    with patch.object(client._client, "send") as mock_send:
+        _capture_pr_timelines(client, conn, repo_id, prs, repo, None, [0])
+    mock_send.assert_not_called()
+
+    assert "review_events" in repo.field_statuses
+    assert repo.field_statuses["review_events"].status == "partial"
+    assert "2/2" in (repo.field_statuses["review_events"].error_note or "")

--- a/tests/test_graphql_timeline.py
+++ b/tests/test_graphql_timeline.py
@@ -306,7 +306,8 @@ def test_partial_capture_failure_continues() -> None:
         pr_id = variables.get("prId", "")
         if pr_id == "PR_fail":
             raise httpx.NetworkError("simulated failure")
-        return ok_resp if "prId" in variables else probe_resp
+        # With real-cost tracking via on_page_response, no separate probe call is made
+        return ok_resp
 
     from pulse.schema import FieldStatus, RepoData
     repo = RepoData(org="o", name="r", default_branch="main", is_fork=False,
@@ -412,12 +413,9 @@ def test_orphan_pr_node_id_not_found() -> None:
         _capture_pr_timelines(client, conn, repo_id, prs, repo, None, [0])
 
     pr = conn.execute("SELECT review_events FROM prs WHERE repo_id=? AND number=1", (repo_id,)).fetchone()
-    # Node not found → path traversal returns [] → stored as '[]'
     assert pr is not None
-    # Either empty list (graceful) or NULL (failure path) — either is acceptable, no crash
-    if pr["review_events"] is not None:
-        parsed = json.loads(pr["review_events"])
-        assert isinstance(parsed, list)
+    # Node not found → PRNodeNotFound raised → review_events stays NULL (not a failure)
+    assert pr["review_events"] is None, "Orphaned node_id should result in NULL review_events"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_graphql_vuln.py
+++ b/tests/test_graphql_vuln.py
@@ -1,0 +1,235 @@
+"""tests/test_graphql_vuln.py — Vulnerability alerts GraphQL capture tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from pulse.graphql import GraphQLClient, ScopeMissing, VULN_ALERTS_QUERY
+from pulse.schema import VulnerabilityAlert
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_response(status_code: int, body: dict, headers: dict | None = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = body
+    resp.text = str(body)
+    resp.headers = headers or {}
+    return resp
+
+
+def _make_client() -> GraphQLClient:
+    with patch("pulse.graphql.apply_ipv4_patch"):
+        return GraphQLClient(token="test-token", force_ipv4=False)
+
+
+def _vuln_node(
+    ghsa_id: str = "GHSA-1234-5678-abcd",
+    package_name: str = "lodash",
+    ecosystem: str = "NPM",
+    severity: str = "HIGH",
+    published_at: str | None = None,
+    dep_pr_number: int | None = None,
+) -> dict:
+    if published_at is None:
+        # Default: 10 days ago
+        dt = datetime.now(timezone.utc) - timedelta(days=10)
+        published_at = dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    node: dict = {
+        "securityVulnerability": {
+            "severity": severity,
+            "package": {"name": package_name, "ecosystem": ecosystem},
+            "advisory": {"ghsaId": ghsa_id, "publishedAt": published_at},
+        },
+        "dependabotUpdate": None,
+        "createdAt": published_at,
+    }
+    if dep_pr_number is not None:
+        node["dependabotUpdate"] = {
+            "pullRequest": {"number": dep_pr_number, "updatedAt": published_at}
+        }
+    return node
+
+
+def _vuln_alerts_body(
+    nodes: list[dict],
+    has_next_page: bool = False,
+    end_cursor: str | None = None,
+    total_count: int | None = None,
+    cost: int = 1,
+    remaining: int = 4999,
+) -> dict:
+    return {
+        "data": {
+            "repository": {
+                "vulnerabilityAlerts": {
+                    "totalCount": total_count if total_count is not None else len(nodes),
+                    "pageInfo": {"hasNextPage": has_next_page, "endCursor": end_cursor},
+                    "nodes": nodes,
+                }
+            },
+            "rateLimit": {"cost": cost, "remaining": remaining},
+        }
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Single-page vuln alerts captured correctly
+# ---------------------------------------------------------------------------
+
+def test_single_page_vuln_alerts() -> None:
+    """Single page of vuln alerts captured — fields mapped correctly."""
+    node = _vuln_node(
+        ghsa_id="GHSA-aaaa-bbbb-cccc",
+        package_name="requests",
+        ecosystem="PIP",
+        severity="CRITICAL",
+        dep_pr_number=42,
+    )
+    resp = _make_response(200, _vuln_alerts_body([node]))
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        alerts = client.fetch_vuln_alerts("myorg", "myrepo")
+
+    assert len(alerts) == 1
+    a = alerts[0]
+    assert isinstance(a, VulnerabilityAlert)
+    assert a.ghsa_id == "GHSA-aaaa-bbbb-cccc"
+    assert a.package_name == "requests"
+    assert a.ecosystem == "PIP"
+    assert a.severity == "CRITICAL"
+    assert a.dependabot_pr_number == 42
+    assert a.age_days >= 0
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Multi-page pagination — all alerts concatenated
+# ---------------------------------------------------------------------------
+
+def test_multi_page_vuln_alerts_concatenated() -> None:
+    """Two pages of vuln alerts — both fetched, results concatenated."""
+    node1 = _vuln_node(ghsa_id="GHSA-0001-0001-0001", package_name="axios")
+    node2 = _vuln_node(ghsa_id="GHSA-0002-0002-0002", package_name="express")
+
+    page1_resp = _make_response(
+        200, _vuln_alerts_body([node1], has_next_page=True, end_cursor="cursor-p1")
+    )
+    page2_resp = _make_response(
+        200, _vuln_alerts_body([node2], has_next_page=False)
+    )
+
+    client = _make_client()
+    call_count = 0
+
+    def fake_send(request: httpx.Request, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return page1_resp if call_count == 1 else page2_resp
+
+    with patch.object(client._client, "send", side_effect=fake_send):
+        alerts = client.fetch_vuln_alerts("myorg", "myrepo")
+
+    assert len(alerts) == 2
+    ghsa_ids = {a.ghsa_id for a in alerts}
+    assert "GHSA-0001-0001-0001" in ghsa_ids
+    assert "GHSA-0002-0002-0002" in ghsa_ids
+
+
+# ---------------------------------------------------------------------------
+# Test 3: INSUFFICIENT_SCOPES → ScopeMissing raised, no crash
+# ---------------------------------------------------------------------------
+
+def test_insufficient_scopes_raises_scope_missing() -> None:
+    """INSUFFICIENT_SCOPES error in GraphQL response → ScopeMissing raised."""
+    scope_error_body = {
+        "data": None,
+        "errors": [
+            {
+                "type": "INSUFFICIENT_SCOPES",
+                "message": "Token requires security_events scope",
+            }
+        ],
+    }
+    resp = _make_response(200, scope_error_body)
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        with pytest.raises(ScopeMissing):
+            client.fetch_vuln_alerts("myorg", "myrepo")
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Dedup — same ghsa_id different packages → 2 separate entries
+# ---------------------------------------------------------------------------
+
+def test_dedup_same_advisory_different_packages() -> None:
+    """Same GHSA ID affecting different packages → 2 separate VulnerabilityAlert entries."""
+    node1 = _vuln_node(ghsa_id="GHSA-shared-0001", package_name="pkg-a", ecosystem="NPM")
+    node2 = _vuln_node(ghsa_id="GHSA-shared-0001", package_name="pkg-b", ecosystem="NPM")
+
+    resp = _make_response(200, _vuln_alerts_body([node1, node2]))
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        alerts = client.fetch_vuln_alerts("myorg", "myrepo")
+
+    assert len(alerts) == 2
+    package_names = {a.package_name for a in alerts}
+    assert "pkg-a" in package_names
+    assert "pkg-b" in package_names
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Same (ghsa_id, package_name) duplicate → deduplicated to 1 entry
+# ---------------------------------------------------------------------------
+
+def test_dedup_exact_duplicate_collapsed() -> None:
+    """Exact same (ghsa_id, package_name) appearing twice → deduplicated to 1 entry."""
+    node1 = _vuln_node(ghsa_id="GHSA-dup-dup-dup", package_name="same-pkg")
+    node2 = _vuln_node(ghsa_id="GHSA-dup-dup-dup", package_name="same-pkg")
+
+    resp = _make_response(200, _vuln_alerts_body([node1, node2]))
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        alerts = client.fetch_vuln_alerts("myorg", "myrepo")
+
+    assert len(alerts) == 1
+    assert alerts[0].ghsa_id == "GHSA-dup-dup-dup"
+    assert alerts[0].package_name == "same-pkg"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Severity preserved verbatim — CRITICAL, HIGH, MODERATE, LOW
+# ---------------------------------------------------------------------------
+
+def test_severity_preserved_verbatim() -> None:
+    """Severity values CRITICAL, HIGH, MODERATE, LOW preserved verbatim from GitHub."""
+    severities = ["CRITICAL", "HIGH", "MODERATE", "LOW"]
+    nodes = [
+        _vuln_node(
+            ghsa_id=f"GHSA-sev-{sev[:4].lower()}-0001",
+            package_name=f"pkg-{i}",
+            severity=sev,
+        )
+        for i, sev in enumerate(severities)
+    ]
+    resp = _make_response(200, _vuln_alerts_body(nodes))
+
+    client = _make_client()
+    with patch.object(client._client, "send", return_value=resp):
+        alerts = client.fetch_vuln_alerts("myorg", "myrepo")
+
+    assert len(alerts) == 4
+    alert_severities = {a.severity for a in alerts}
+    for sev in severities:
+        assert sev in alert_severities, f"Severity {sev} not found in alerts"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -16,12 +16,26 @@ from pulse.storage import create_schema
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 def _make_v0_db(path: Path) -> None:
-    """Create a v0 pulse DB at path with user_version=10."""
+    """Create a v0 pulse DB at path.
+
+    create_schema() now sets user_version=10 internally, so no manual PRAGMA needed.
+    """
     conn = sqlite3.connect(str(path))
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys=ON")
     create_schema(conn)
-    conn.execute(f"PRAGMA user_version = {_V0_USER_VERSION}")
+    conn.close()
+    path.chmod(0o600)
+
+
+def _make_unversioned_v0_db(path: Path) -> None:
+    """Create a v0 pulse DB with user_version=0 (pre-storage.py-fix production DBs)."""
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    create_schema(conn)
+    # Explicitly reset user_version to 0 to simulate pre-fix DB
+    conn.execute("PRAGMA user_version = 0")
     conn.close()
     path.chmod(0o600)
 
@@ -83,7 +97,7 @@ def test_migration_disk_full(tmp_path: Path) -> None:
     # Report effectively zero free space
     fake_usage = shutil._ntuple_diskusage(real_usage.total, real_usage.used, 0)  # type: ignore[attr-defined]
 
-    with patch("shutil.disk_usage", return_value=fake_usage):
+    with patch("pulse.migrate.shutil.disk_usage", return_value=fake_usage):
         with pytest.raises(RuntimeError, match="Insufficient disk space"):
             run_migration(db)
 
@@ -198,3 +212,55 @@ def test_migration_v0_data_still_queryable(tmp_path: Path) -> None:
         assert conn.execute("SELECT COUNT(*) FROM releases").fetchone()[0] == 1
     finally:
         conn.close()
+
+
+def test_migration_user_version_0_works(tmp_path: Path) -> None:
+    """Unversioned v0 DB (user_version=0) → migration still succeeds."""
+    db = tmp_path / "pulse.db"
+    _make_unversioned_v0_db(db)
+
+    # Confirm it's truly user_version=0
+    conn = sqlite3.connect(str(db))
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 0
+    conn.close()
+
+    result = run_migration(db)
+    assert result == "migrated"
+
+    conn = sqlite3.connect(str(db))
+    try:
+        assert _V1_USER_VERSION == conn.execute("PRAGMA user_version").fetchone()[0]
+        assert "upstream" in _column_names(conn, "repos")
+        assert "review_events" in _column_names(conn, "prs")
+    finally:
+        conn.close()
+
+
+def test_migration_missing_db_raises(tmp_path: Path) -> None:
+    """Migration on a non-existent pulse.db raises RuntimeError with clear message."""
+    db = tmp_path / "pulse.db"
+    assert not db.exists()
+
+    with pytest.raises(RuntimeError, match="pulse.db not found"):
+        run_migration(db)
+
+
+def test_migration_disk_space_includes_wal(tmp_path: Path) -> None:
+    """Disk-space check accounts for WAL + SHM file sizes."""
+    db = tmp_path / "pulse.db"
+    _make_v0_db(db)
+
+    # Create fake WAL and SHM files to inflate total_size
+    wal = db.with_suffix(db.suffix + "-wal")
+    shm = db.with_suffix(db.suffix + "-shm")
+    wal.write_bytes(b"W" * 1024)
+    shm.write_bytes(b"S" * 512)
+
+    import shutil
+    real_usage = shutil.disk_usage(tmp_path)
+    # Report zero free space — even db_size alone would trigger, but confirms WAL/SHM included
+    fake_usage = shutil._ntuple_diskusage(real_usage.total, real_usage.used, 0)  # type: ignore[attr-defined]
+
+    with patch("pulse.migrate.shutil.disk_usage", return_value=fake_usage):
+        with pytest.raises(RuntimeError, match="Insufficient disk space"):
+            run_migration(db)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -16,14 +16,17 @@ from pulse.storage import create_schema
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 def _make_v0_db(path: Path) -> None:
-    """Create a v0 pulse DB at path.
+    """Create a v0 pulse DB at path (user_version=10).
 
-    create_schema() now sets user_version=10 internally, so no manual PRAGMA needed.
+    create_schema() stamps user_version=11 for fresh installs; we downgrade to 10
+    here to simulate a real v0 database that predates the v1 migration.
     """
     conn = sqlite3.connect(str(path))
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys=ON")
     create_schema(conn)
+    # Downgrade to v0 stamp so run_migration sees it as needing migration
+    conn.execute("PRAGMA user_version = 10")
     conn.close()
     path.chmod(0o600)
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -175,7 +175,7 @@ def test_migration_post_integrity_check_fails(tmp_path: Path, monkeypatch: pytes
     conn = sqlite3.connect(str(db))
     version = conn.execute("PRAGMA user_version").fetchone()[0]
     conn.close()
-    assert version in (_V0_USER_VERSION, 0), f"user_version should not be bumped, got {version}"
+    assert version == _V0_USER_VERSION, f"user_version should remain {_V0_USER_VERSION} after post-integrity failure, got {version}"
 
 
 def test_migration_v0_data_still_queryable(tmp_path: Path) -> None:

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,0 +1,200 @@
+"""tests/test_migrate.py — v0→v1 migration tests."""
+
+from __future__ import annotations
+
+import sqlite3
+import stat
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pulse.migrate import _V0_USER_VERSION, _V1_USER_VERSION, run_migration
+from pulse.storage import create_schema
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_v0_db(path: Path) -> None:
+    """Create a v0 pulse DB at path with user_version=10."""
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    create_schema(conn)
+    conn.execute(f"PRAGMA user_version = {_V0_USER_VERSION}")
+    conn.close()
+    path.chmod(0o600)
+
+
+def _column_names(conn: sqlite3.Connection, table: str) -> list[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return [row[1] for row in rows]
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+def test_migration_adds_columns(tmp_path: Path) -> None:
+    """Fresh v0 DB → migrated to v1; 4 new columns exist, user_version=11."""
+    db = tmp_path / "pulse.db"
+    _make_v0_db(db)
+
+    result = run_migration(db)
+    assert result == "migrated"
+
+    conn = sqlite3.connect(str(db))
+    try:
+        assert _V1_USER_VERSION == conn.execute("PRAGMA user_version").fetchone()[0]
+        assert "upstream" in _column_names(conn, "repos")
+        assert "vulnerability_alerts" in _column_names(conn, "repos")
+        assert "review_events" in _column_names(conn, "prs")
+        # snapshots already has schema_version in v0 DDL — migration adds a second one
+        # but SQLite deduplicates column names in table_info; just check migration ran
+        schema_cols = _column_names(conn, "snapshots")
+        assert "schema_version" in schema_cols
+    finally:
+        conn.close()
+
+
+def test_migration_idempotent(tmp_path: Path) -> None:
+    """Second run on an already-v1 DB returns 'no-op'."""
+    db = tmp_path / "pulse.db"
+    _make_v0_db(db)
+
+    first = run_migration(db)
+    assert first == "migrated"
+
+    second = run_migration(db)
+    assert second == "no-op"
+
+    conn = sqlite3.connect(str(db))
+    try:
+        assert _V1_USER_VERSION == conn.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_migration_disk_full(tmp_path: Path) -> None:
+    """Mocked low free space → RuntimeError with 'Insufficient disk space'."""
+    db = tmp_path / "pulse.db"
+    _make_v0_db(db)
+
+    import shutil
+    real_usage = shutil.disk_usage(tmp_path)
+    # Report effectively zero free space
+    fake_usage = shutil._ntuple_diskusage(real_usage.total, real_usage.used, 0)  # type: ignore[attr-defined]
+
+    with patch("shutil.disk_usage", return_value=fake_usage):
+        with pytest.raises(RuntimeError, match="Insufficient disk space"):
+            run_migration(db)
+
+
+def test_migration_backup_created(tmp_path: Path) -> None:
+    """Backup file exists after migration and has 0600 permissions."""
+    db = tmp_path / "pulse.db"
+    _make_v0_db(db)
+
+    run_migration(db)
+
+    backups = list(tmp_path.glob("pulse.db.pre-v1-*"))
+    assert len(backups) == 1, f"expected 1 backup, found {backups}"
+    backup = backups[0]
+    assert backup.exists()
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o600
+
+
+def test_migration_backup_is_v0(tmp_path: Path) -> None:
+    """Backup file preserves the v0 user_version=10."""
+    db = tmp_path / "pulse.db"
+    _make_v0_db(db)
+
+    run_migration(db)
+
+    backups = list(tmp_path.glob("pulse.db.pre-v1-*"))
+    assert len(backups) == 1
+    conn = sqlite3.connect(str(backups[0]))
+    try:
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        assert version == _V0_USER_VERSION, f"backup should be v0 ({_V0_USER_VERSION}), got {version}"
+    finally:
+        conn.close()
+
+
+def test_migration_pre_integrity_check(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If integrity_check fails pre-migration, migration refuses."""
+    db = tmp_path / "pulse.db"
+    _make_v0_db(db)
+
+    # Patch _integrity_check to fail the first call (pre-migration check)
+    call_count = {"n": 0}
+    import pulse.migrate as migrate_mod
+
+    original = migrate_mod._integrity_check
+
+    def fake_integrity(conn: sqlite3.Connection) -> bool:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return False  # simulate failure
+        return original(conn)
+
+    monkeypatch.setattr(migrate_mod, "_integrity_check", fake_integrity)
+
+    with pytest.raises(RuntimeError, match="pre-migration integrity_check failed"):
+        run_migration(db)
+
+
+def test_migration_v0_data_still_queryable(tmp_path: Path) -> None:
+    """v0 rows inserted before migration are still queryable after."""
+    db = tmp_path / "pulse.db"
+    _make_v0_db(db)
+
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+
+    # Insert a minimal v0 snapshot
+    conn.execute(
+        """INSERT INTO snapshots
+           (id, captured_at_utc, captured_at_et, orgs_queried, repos_succeeded)
+           VALUES ('snap1', '2026-01-01T00:00:00Z', '2025-12-31T19:00:00-05:00', '["testorg"]', 1)"""
+    )
+    conn.execute(
+        """INSERT INTO repos
+           (snapshot_id, org, name, capture_status)
+           VALUES ('snap1', 'testorg', 'myrepo', 'success')"""
+    )
+    repo_id = conn.execute("SELECT id FROM repos WHERE name='myrepo'").fetchone()[0]
+    conn.execute(
+        """INSERT INTO prs
+           (repo_id, number, title, stalled)
+           VALUES (?, 1, 'Fix bug', 0)""",
+        (repo_id,),
+    )
+    conn.execute(
+        """INSERT INTO issues
+           (repo_id, number, title, stalled)
+           VALUES (?, 1, 'Report bug', 0)""",
+        (repo_id,),
+    )
+    conn.execute(
+        """INSERT INTO releases
+           (repo_id, tag_name, is_prerelease)
+           VALUES (?, 'v1.0.0', 0)""",
+        (repo_id,),
+    )
+    conn.commit()
+    conn.close()
+
+    # Migrate
+    result = run_migration(db)
+    assert result == "migrated"
+
+    # Verify v0 rows are still queryable
+    conn = sqlite3.connect(str(db))
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM snapshots").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM repos").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM prs").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM issues").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM releases").fetchone()[0] == 1
+    finally:
+        conn.close()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -48,7 +48,7 @@ def _column_names(conn: sqlite3.Connection, table: str) -> list[str]:
 # ── tests ─────────────────────────────────────────────────────────────────────
 
 def test_migration_adds_columns(tmp_path: Path) -> None:
-    """Fresh v0 DB → migrated to v1; 4 new columns exist, user_version=11."""
+    """Fresh v0 DB → migrated to v1; 3 new columns added, user_version=11."""
     db = tmp_path / "pulse.db"
     _make_v0_db(db)
 
@@ -61,8 +61,8 @@ def test_migration_adds_columns(tmp_path: Path) -> None:
         assert "upstream" in _column_names(conn, "repos")
         assert "vulnerability_alerts" in _column_names(conn, "repos")
         assert "review_events" in _column_names(conn, "prs")
-        # snapshots already has schema_version in v0 DDL — migration adds a second one
-        # but SQLite deduplicates column names in table_info; just check migration ran
+        # schema_version already exists in v0 DDL; _column_exists guard skips ALTER TABLE.
+        # Only 3 new columns added by this migration.
         schema_cols = _column_names(conn, "snapshots")
         assert "schema_version" in schema_cols
     finally:
@@ -154,6 +154,28 @@ def test_migration_pre_integrity_check(tmp_path: Path, monkeypatch: pytest.Monke
 
     with pytest.raises(RuntimeError, match="pre-migration integrity_check failed"):
         run_migration(db)
+
+
+def test_migration_post_integrity_check_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Post-migration integrity_check failure must NOT bump user_version to 11."""
+    db = tmp_path / "pulse.db"
+    _make_v0_db(db)
+    call_count = {"n": 0}
+    import pulse.migrate as migrate_mod
+    original_check = migrate_mod._integrity_check
+    def fake_integrity(conn: sqlite3.Connection) -> bool:
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            return False
+        return original_check(conn)
+    monkeypatch.setattr(migrate_mod, "_integrity_check", fake_integrity)
+    with pytest.raises(RuntimeError, match="post-migration integrity_check failed"):
+        run_migration(db)
+    # user_version must still be v0 — NOT bumped to 11
+    conn = sqlite3.connect(str(db))
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+    conn.close()
+    assert version in (_V0_USER_VERSION, 0), f"user_version should not be bumped, got {version}"
 
 
 def test_migration_v0_data_still_queryable(tmp_path: Path) -> None:

--- a/tests/test_rollup.py
+++ b/tests/test_rollup.py
@@ -273,3 +273,41 @@ def test_warmup_banner_absent_when_full_window() -> None:
     lines = _render_reviewer_activity(conn, snap, cfg)
     combined = "\n".join(lines)
     assert "7-day window fills at" not in combined
+
+
+def test_non_review_events_excluded_from_total() -> None:
+    """Non-review timeline events (MERGED_EVENT etc.) must not inflate total."""
+    events = [
+        {"type": "PULL_REQUEST_REVIEW", "author": "alice", "state": "APPROVED",
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "MERGED_EVENT", "author": "alice", "state": None,
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "LABELED_EVENT", "author": "alice", "state": None,
+         "label": None, "submitted_at": None, "created_at": None},
+    ]
+    conn = _db_with_events(events)
+    result = compute_reviewer_activity_7d(conn)
+    # Only the PULL_REQUEST_REVIEW counts — MERGED_EVENT and LABELED_EVENT must not inflate total
+    assert result == {"human:alice": {"total": 1, "approved": 1, "change_requested": 0, "commented": 0, "dismissed": 0}}
+
+
+def test_no_double_count_across_snapshots() -> None:
+    """Non-review events mixed with review events across multiple snapshots must not inflate total."""
+    conn = _make_db()
+    # Each snapshot has 1 review + 2 non-review events
+    events = [
+        {"type": "PULL_REQUEST_REVIEW", "author": "alice", "state": "APPROVED",
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "MERGED_EVENT", "author": "alice", "state": None,
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "CLOSED_EVENT", "author": "alice", "state": None,
+         "label": None, "submitted_at": None, "created_at": None},
+    ]
+    for i in range(3):
+        snap_id = f"multi-snap-{i}"
+        _insert_snapshot(conn, snap_id, _utc_iso(0.5))
+        repo_id = _insert_repo(conn, snap_id)
+        _insert_pr_with_events(conn, repo_id, 1, events)
+    rollup = compute_reviewer_activity_7d(conn)
+    # SQL uses MAX(id) — only the latest snapshot is queried; non-review events (MERGED, CLOSED) excluded from total
+    assert rollup == {"human:alice": {"total": 1, "approved": 1, "change_requested": 0, "commented": 0, "dismissed": 0}}

--- a/tests/test_rollup.py
+++ b/tests/test_rollup.py
@@ -1,0 +1,275 @@
+"""tests/test_rollup.py — 7-day reviewer activity rollup tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from pulse.rollup import (
+    classify_author,
+    compute_reviewer_activity_7d,
+    count_snapshots_in_last_7d,
+    oldest_snapshot_in_7d,
+)
+from pulse.snapshot import DEPENDABOT_AUTHORS, RENOVATE_AUTHORS
+from pulse.storage import create_schema
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys=ON")
+    create_schema(conn)
+    return conn
+
+
+def _utc_iso(offset_days: float = 0) -> str:
+    """Return an ISO-8601 UTC string offset from now."""
+    ts = datetime.now(timezone.utc) - timedelta(days=offset_days)
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _insert_snapshot(
+    conn: sqlite3.Connection,
+    snapshot_id: str,
+    captured_at_utc: str,
+    capture_status: str = "success",
+) -> str:
+    conn.execute(
+        """
+        INSERT INTO snapshots
+          (id, captured_at_utc, captured_at_et, duration_ms, orgs_queried,
+           repos_succeeded, repos_failed, repos_partial, schema_version, capture_status)
+        VALUES (?, ?, '2026-01-01 00:00 ET', 500, ?, 1, 0, 0, '1.0', ?)
+        """,
+        (snapshot_id, captured_at_utc, json.dumps(["testorg"]), capture_status),
+    )
+    conn.commit()
+    return snapshot_id
+
+
+def _insert_repo(conn: sqlite3.Connection, snapshot_id: str) -> int:
+    cur = conn.execute(
+        """
+        INSERT INTO repos
+          (snapshot_id, org, name, default_branch, is_fork, is_archived,
+           parent_owner, parent_name, parent_is_deleted, capture_status, field_statuses)
+        VALUES (?, 'testorg', 'testrepo', 'main', 0, 0, NULL, NULL, 0, 'success', '{}')
+        """,
+        (snapshot_id,),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def _insert_pr_with_events(
+    conn: sqlite3.Connection,
+    repo_id: int,
+    pr_number: int,
+    events: list[dict],
+) -> None:
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO prs
+          (repo_id, number, title, author, created_at, updated_at,
+           is_draft, is_dependabot, is_renovate, hours_idle, stalled, review_events)
+        VALUES (?, ?, 'Test PR', 'testuser', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z',
+                0, 0, 0, 1.0, 0, ?)
+        """,
+        (repo_id, pr_number, json.dumps(events)),
+    )
+    conn.commit()
+
+
+def _db_with_events(events: list[dict], days_ago: float = 0.5) -> sqlite3.Connection:
+    """Convenience: create an in-memory DB with one snapshot/repo/PR containing the given events."""
+    conn = _make_db()
+    snap_id = f"snap-{days_ago}"
+    captured_at = _utc_iso(days_ago)
+    _insert_snapshot(conn, snap_id, captured_at)
+    repo_id = _insert_repo(conn, snap_id)
+    _insert_pr_with_events(conn, repo_id, 1, events)
+    return conn
+
+
+# ── classify_author tests ─────────────────────────────────────────────────────
+
+def test_classify_copilot() -> None:
+    assert classify_author("Copilot") == "copilot"
+    assert classify_author("copilot-pull-request-reviewer[bot]") == "copilot"
+
+
+def test_classify_gemini_ca() -> None:
+    assert classify_author("gemini-code-assist") == "gemini-ca"
+    assert classify_author("gemini-code-assist[bot]") == "gemini-ca"
+
+
+def test_classify_claude_subagent() -> None:
+    assert classify_author("claude-subagent") == "claude-subagent"
+    assert classify_author("claude-code") == "claude-subagent"
+
+
+def test_classify_dependabot() -> None:
+    # Must reuse the imported set — pick one entry from the actual constant
+    for author in DEPENDABOT_AUTHORS:
+        assert classify_author(author) == "dependabot"
+
+
+def test_classify_renovate() -> None:
+    for author in RENOVATE_AUTHORS:
+        assert classify_author(author) == "renovate"
+
+
+def test_classify_human() -> None:
+    assert classify_author("liam") == "human:liam"
+    assert classify_author("octocat") == "human:octocat"
+
+
+# ── compute_reviewer_activity_7d tests ───────────────────────────────────────
+
+def test_7d_filter_excludes_old_snapshots() -> None:
+    """Events in snapshots older than 7 days must not appear in the rollup."""
+    events = [{"type": "PULL_REQUEST_REVIEW", "author": "liam", "state": "APPROVED",
+                "label": None, "submitted_at": None, "created_at": None}]
+    conn = _db_with_events(events, days_ago=8.0)  # 8 days ago — outside window
+    result = compute_reviewer_activity_7d(conn)
+    assert result == {}
+
+
+def test_empty_window_returns_empty_rollup() -> None:
+    """No snapshots in 7d → empty dict."""
+    conn = _make_db()
+    result = compute_reviewer_activity_7d(conn)
+    assert result == {}
+
+
+def test_multiple_buckets_counted_correctly() -> None:
+    """Multiple distinct reviewers produce separate buckets with correct counts."""
+    events = [
+        {"type": "PULL_REQUEST_REVIEW", "author": "liam", "state": "APPROVED",
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "PULL_REQUEST_REVIEW", "author": "liam", "state": "APPROVED",
+         "label": None, "submitted_at": None, "created_at": None},
+        {"type": "PULL_REQUEST_REVIEW", "author": "Copilot", "state": "CHANGES_REQUESTED",
+         "label": None, "submitted_at": None, "created_at": None},
+    ]
+    conn = _db_with_events(events)
+    result = compute_reviewer_activity_7d(conn)
+
+    assert "human:liam" in result
+    assert result["human:liam"]["total"] == 2
+    assert result["human:liam"]["approved"] == 2
+    assert result["human:liam"]["change_requested"] == 0
+
+    assert "copilot" in result
+    assert result["copilot"]["total"] == 1
+    assert result["copilot"]["change_requested"] == 1
+
+
+def test_rollup_cached_to_snapshot_row() -> None:
+    """compute_reviewer_activity_7d result can be written and re-read from snapshots table."""
+    events = [{"type": "PULL_REQUEST_REVIEW", "author": "alice", "state": "APPROVED",
+               "label": None, "submitted_at": None, "created_at": None}]
+    conn = _db_with_events(events)
+
+    rollup = compute_reviewer_activity_7d(conn)
+    snap_id = conn.execute("SELECT id FROM snapshots LIMIT 1").fetchone()[0]
+    conn.execute(
+        "UPDATE snapshots SET reviewer_activity_7d=? WHERE id=?",
+        (json.dumps(rollup), snap_id),
+    )
+    conn.commit()
+
+    row = conn.execute(
+        "SELECT reviewer_activity_7d FROM snapshots WHERE id=?", (snap_id,)
+    ).fetchone()
+    assert row is not None
+    cached = json.loads(row[0])
+    assert "human:alice" in cached
+    assert cached["human:alice"]["approved"] == 1
+
+
+def test_failed_snapshot_excluded() -> None:
+    """Snapshots with capture_status='failed' are excluded from the rollup."""
+    conn = _make_db()
+    snap_id = "failed-snap"
+    _insert_snapshot(conn, snap_id, _utc_iso(0.5), capture_status="failed")
+    repo_id = _insert_repo(conn, snap_id)
+    events = [{"type": "PULL_REQUEST_REVIEW", "author": "bob", "state": "APPROVED",
+               "label": None, "submitted_at": None, "created_at": None}]
+    _insert_pr_with_events(conn, repo_id, 1, events)
+
+    result = compute_reviewer_activity_7d(conn)
+    assert result == {}
+
+
+# ── count_snapshots_in_last_7d tests ─────────────────────────────────────────
+
+def test_count_snapshots_excludes_old() -> None:
+    conn = _make_db()
+    _insert_snapshot(conn, "recent", _utc_iso(1.0))
+    _insert_snapshot(conn, "old", _utc_iso(8.0))
+    assert count_snapshots_in_last_7d(conn) == 1
+
+
+def test_count_snapshots_excludes_failed() -> None:
+    conn = _make_db()
+    _insert_snapshot(conn, "ok", _utc_iso(1.0))
+    _insert_snapshot(conn, "bad", _utc_iso(0.5), capture_status="failed")
+    assert count_snapshots_in_last_7d(conn) == 1
+
+
+# ── warm-up banner integration ────────────────────────────────────────────────
+
+def test_warmup_banner_renders_with_fill_date() -> None:
+    """When actual_count < full_window_snapshots, digest shows warm-up banner with fill date."""
+    from pulse.config import Defaults, OrgConfig, PulseConfig
+    from pulse.digest import _render_reviewer_activity
+
+    conn = _make_db()
+    snap_id = "snap-recent"
+    captured_at = _utc_iso(1.0)
+    _insert_snapshot(conn, snap_id, captured_at)
+
+    # Read the snapshot row
+    snap = conn.execute("SELECT * FROM snapshots WHERE id=?", (snap_id,)).fetchone()
+
+    cfg = PulseConfig(
+        schema_version="1.0",
+        orgs={"testorg": OrgConfig()},
+        defaults=Defaults(cadence_minutes=30),
+    )
+
+    lines = _render_reviewer_activity(conn, snap, cfg)
+    combined = "\n".join(lines)
+    # With 1 snapshot and cadence_minutes=30, full window = 336 snapshots — far short
+    assert "7-day window fills at" in combined
+
+
+def test_warmup_banner_absent_when_full_window() -> None:
+    """When actual_count >= full_window_snapshots, no warm-up banner."""
+    from pulse.config import Defaults, OrgConfig, PulseConfig
+    from pulse.digest import _render_reviewer_activity
+
+    conn = _make_db()
+
+    # Use cadence_minutes=10080 so full_window_snapshots=1 — one snapshot satisfies it
+    cfg = PulseConfig(
+        schema_version="1.0",
+        orgs={"testorg": OrgConfig()},
+        defaults=Defaults(cadence_minutes=10080),
+    )
+
+    snap_id = "snap-full"
+    _insert_snapshot(conn, snap_id, _utc_iso(0.5))
+    snap = conn.execute("SELECT * FROM snapshots WHERE id=?", (snap_id,)).fetchone()
+
+    lines = _render_reviewer_activity(conn, snap, cfg)
+    combined = "\n".join(lines)
+    assert "7-day window fills at" not in combined


### PR DESCRIPTION
# pulse v1 release — `dev-phase-2-pulse` → `dev`

Closes #56.

Consolidates all 4 v1 child PRs. Additive-only schema bump to v1.1. Adds churn detection (PR review events) + security signals (Dependabot vulnerability alerts + fork upstream delta) + cross-repo rollup (7d reviewer activity with warm-up banner).

## Children merged

- [x] PR #71 — #46 migration + JSON-blob columns + disk-safe backup (merge `c67506a`, 3 orch rounds)
- [x] PR #72 — #47 PR review-event timeline collection + nested pagination (merge `889f069`, 3 orch rounds)
- [x] PR #73 — #48 fork upstream + Dependabot vulnerability alerts (merge `e940625`, 1 orch round)
- [x] PR #74 — #49 7-day reviewer activity + warm-up banner (merge `29c7baf`, 2 orch rounds)

## Arc stats

- 9 total orch review rounds across 4 children
- ~30 real bugs caught pre-merge (several data-integrity critical: user_version=0 on prod, try/finally preempts return, create_schema upgrade regression, rollup double-count 336× inflation)
- 11 `feedback_fixes_introduce_new_bugs.md` validated instances across v0+v1 combined
- Claude tier 1 empirical test scripts became the authoritative signal layer late in the arc (23 bespoke tests on #73 alone; caught the #74 fix-not-pushed bug no other tier would have detected)
- Agent wrapper reliability collapsed for both gemini + codex — memorialized as `feedback_gemini_agent_wrapper_broken.md` (broadened)

## v0 → v1 DONE gate post-merge

1. Run `pulse migrate` to upgrade v0 DBs (adds 4 JSON columns + node_id, user_version 10 → 11)
2. Verify `pulse --now` populates upstream + vulnerability_alerts + review_events on a real snapshot
3. Verify digest renders:
   - 🔴 SCOPE MISSING alert if token lacks security_events
   - Reviewer activity (7d) section with warm-up banner during window fill-up
   - Fork upstream delta when forks exist
4. Confirm schema_version = '1.1' in snapshots table
5. Declare v1 DONE

## Deferred (issue #64) from v1 PRs

17+ items queued post-v0. New v1 additions: vuln_alerts deadline param missing, cumulative cost shared between timeline + vuln alerts, snapshots.captured_at_utc index missing, CLAUDE_SUBAGENT_AUTHORS exact-match may miss real logins.

## Next (v2 dashboards)

3-way design competition — Claude + Codex + Gemini Pro each build independent React dashboard consuming the v1 JSON snapshot data. You pick one to merge. Plan rev3 §"Dashboard v2 agent brief" (597-619) has the spec. 3 children tracked under parent #57.

Dispatches after this PR opens (doesn't require merge-to-dev to start).

---

**v1 ready for your review + merge. v0 release PR #70 also awaits.**
