### PR TITLE
feat(pulse): v3 OTEL SDK setup + no-op fallback + shutdown flush (#53)

### DIFF
--- a/pulse/__main__.py
+++ b/pulse/__main__.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import atexit
 import dataclasses
 import json
 import os
+import signal
 import stat
 import sys
 import tempfile
@@ -57,6 +59,18 @@ def main(
     if repo_override and not dry_run:
         click.echo("ERROR: --repo requires --dry-run", err=True)
         sys.exit(1)
+
+    from pulse import otel as _otel
+
+    _otel.setup(service_name="pulse")
+
+    def _shutdown_handler(signum: int, frame: object) -> None:
+        _otel.shutdown(timeout_ms=2000)
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, _shutdown_handler)
+    signal.signal(signal.SIGINT, _shutdown_handler)
+    atexit.register(_otel.shutdown)
 
     if config_check:
         _run_config_check()

--- a/pulse/__main__.py
+++ b/pulse/__main__.py
@@ -66,7 +66,7 @@ def main(
 
     def _shutdown_handler(signum: int, frame: object) -> None:
         _otel.shutdown(timeout_ms=2000)
-        sys.exit(0)
+        sys.exit(0 if signum == signal.SIGTERM else 128 + signum)
 
     signal.signal(signal.SIGTERM, _shutdown_handler)
     signal.signal(signal.SIGINT, _shutdown_handler)

--- a/pulse/otel.py
+++ b/pulse/otel.py
@@ -1,0 +1,144 @@
+"""OpenTelemetry SDK initialisation for pulse.
+
+Call ``setup()`` once at program start; call ``shutdown()`` on exit.
+All public functions are safe to call before ``setup()`` — they return
+no-op SDK objects in that case.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Optional
+
+from opentelemetry import metrics, trace
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+_log = logging.getLogger(__name__)
+
+_DEFAULT_TRACES_ENDPOINT = "http://localhost:4318/v1/traces"
+_DEFAULT_METRICS_ENDPOINT = "http://localhost:4318/v1/metrics"
+
+_tracer_provider: Optional[TracerProvider] = None
+_meter_provider: Optional[MeterProvider] = None
+_shutdown_called = False
+_shutdown_lock = threading.Lock()
+
+
+def setup(service_name: str = "pulse", endpoint: str | None = None) -> None:
+    """Initialise TracerProvider and MeterProvider.
+
+    No-op mode: set ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=""`` to load the
+    SDK without attaching any exporter (all trace/metric calls become safe
+    no-ops).
+
+    Unreachable collector: OTLP export errors occur asynchronously during
+    batch export, not at creation time.  The SDK logs them at DEBUG and drops
+    them.  One WARNING is emitted here so operators know the situation.
+    """
+    global _tracer_provider, _meter_provider, _shutdown_called
+
+    with _shutdown_lock:
+        _shutdown_called = False
+
+    resource = Resource.create({SERVICE_NAME: service_name})
+
+    # Determine no-op mode from env var (explicit "" → no-op)
+    traces_env = os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None)
+    no_op = traces_env == ""
+
+    if no_op:
+        # SDK loaded, no exporters — all calls are safe no-ops
+        tp = TracerProvider(resource=resource)
+        trace.set_tracer_provider(tp)
+        _tracer_provider = tp
+
+        mp = MeterProvider(resource=resource)
+        metrics.set_meter_provider(mp)
+        _meter_provider = mp
+        return
+
+    # --- Traces ---
+    traces_endpoint = endpoint or traces_env or _DEFAULT_TRACES_ENDPOINT
+    metrics_env = os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None)
+    metrics_endpoint = metrics_env or _DEFAULT_METRICS_ENDPOINT
+
+    _log.warning(
+        "OTEL: if collector is unreachable at %s, telemetry will be silently "
+        "dropped after first export attempt",
+        traces_endpoint,
+    )
+
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+
+    span_exporter = OTLPSpanExporter(endpoint=traces_endpoint, timeout=5)
+    processor = BatchSpanProcessor(
+        span_exporter,
+        max_queue_size=512,
+        export_timeout_millis=5000,
+        schedule_delay_millis=1000,
+    )
+    tp = TracerProvider(resource=resource)
+    tp.add_span_processor(processor)
+    trace.set_tracer_provider(tp)
+    _tracer_provider = tp
+
+    # --- Metrics ---
+    metric_exporter = OTLPMetricExporter(endpoint=metrics_endpoint, timeout=5)
+    reader = PeriodicExportingMetricReader(
+        metric_exporter,
+        export_interval_millis=15000,
+        export_timeout_millis=5000,
+    )
+    mp = MeterProvider(resource=resource, metric_readers=[reader])
+    metrics.set_meter_provider(mp)
+    _meter_provider = mp
+
+
+def shutdown(timeout_ms: int = 2000) -> None:
+    """Flush and shut down both providers.
+
+    Idempotent — safe to call multiple times.  Never raises.
+    """
+    global _shutdown_called
+
+    with _shutdown_lock:
+        if _shutdown_called:
+            return
+        _shutdown_called = True
+
+    tp = _tracer_provider
+    mp = _meter_provider
+
+    def _do_shutdown() -> None:
+        if tp is not None:
+            try:
+                tp.shutdown()
+            except Exception as exc:
+                _log.warning("OTEL tracer provider shutdown error: %s", exc)
+        if mp is not None:
+            try:
+                mp.shutdown()
+            except Exception as exc:
+                _log.warning("OTEL meter provider shutdown error: %s", exc)
+
+    t = threading.Thread(target=_do_shutdown, daemon=True)
+    t.start()
+    t.join(timeout=timeout_ms / 1000.0)
+    if t.is_alive():
+        _log.warning("OTEL shutdown did not complete within %dms — continuing", timeout_ms)
+
+
+def get_tracer(name: str) -> trace.Tracer:
+    """Convenience wrapper — returns ``trace.get_tracer(name)``."""
+    return trace.get_tracer(name)
+
+
+def get_meter(name: str) -> metrics.Meter:
+    """Convenience wrapper — returns ``metrics.get_meter(name)``."""
+    return metrics.get_meter(name)

--- a/pulse/otel.py
+++ b/pulse/otel.py
@@ -43,29 +43,46 @@ def setup(service_name: str = "pulse", endpoint: str | None = None) -> None:
     global _tracer_provider, _meter_provider, _shutdown_called
 
     with _shutdown_lock:
+        if _tracer_provider is not None:
+            return  # already initialized
         _shutdown_called = False
 
     resource = Resource.create({SERVICE_NAME: service_name})
 
     # Determine no-op mode from env var (explicit "" → no-op)
-    traces_env = os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None)
-    no_op = traces_env == ""
+    traces_endpoint_env = os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None)
+    no_op = traces_endpoint_env == ""
 
     if no_op:
         # SDK loaded, no exporters — all calls are safe no-ops
-        tp = TracerProvider(resource=resource)
+        tp = TracerProvider(resource=resource, shutdown_on_exit=False)
         trace.set_tracer_provider(tp)
         _tracer_provider = tp
 
-        mp = MeterProvider(resource=resource)
+        mp = MeterProvider(resource=resource, shutdown_on_exit=False)
         metrics.set_meter_provider(mp)
         _meter_provider = mp
         return
 
-    # --- Traces ---
-    traces_endpoint = endpoint or traces_env or _DEFAULT_TRACES_ENDPOINT
-    metrics_env = os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None)
-    metrics_endpoint = metrics_env or _DEFAULT_METRICS_ENDPOINT
+    # --- Endpoint resolution with generic fallback ---
+    generic_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "").rstrip("/")
+    metrics_endpoint_env = os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", None)
+
+    if endpoint is not None:
+        traces_endpoint = endpoint
+    elif traces_endpoint_env is not None:
+        traces_endpoint = traces_endpoint_env
+    elif generic_endpoint:
+        traces_endpoint = f"{generic_endpoint}/v1/traces"
+    else:
+        traces_endpoint = _DEFAULT_TRACES_ENDPOINT
+
+    if metrics_endpoint_env is not None:
+        metrics_endpoint = metrics_endpoint_env or _DEFAULT_METRICS_ENDPOINT
+    elif generic_endpoint:
+        metrics_endpoint = f"{generic_endpoint}/v1/metrics"
+    else:
+        metrics_endpoint = _DEFAULT_METRICS_ENDPOINT
 
     _log.warning(
         "OTEL: if collector is unreachable at %s, telemetry will be silently "
@@ -83,7 +100,7 @@ def setup(service_name: str = "pulse", endpoint: str | None = None) -> None:
         export_timeout_millis=5000,
         schedule_delay_millis=1000,
     )
-    tp = TracerProvider(resource=resource)
+    tp = TracerProvider(resource=resource, shutdown_on_exit=False)
     tp.add_span_processor(processor)
     trace.set_tracer_provider(tp)
     _tracer_provider = tp
@@ -95,7 +112,7 @@ def setup(service_name: str = "pulse", endpoint: str | None = None) -> None:
         export_interval_millis=15000,
         export_timeout_millis=5000,
     )
-    mp = MeterProvider(resource=resource, metric_readers=[reader])
+    mp = MeterProvider(resource=resource, metric_readers=[reader], shutdown_on_exit=False)
     metrics.set_meter_provider(mp)
     _meter_provider = mp
 
@@ -111,9 +128,8 @@ def shutdown(timeout_ms: int = 2000) -> None:
         if _shutdown_called:
             return
         _shutdown_called = True
-
-    tp = _tracer_provider
-    mp = _meter_provider
+        tp = _tracer_provider   # capture inside lock
+        mp = _meter_provider    # capture inside lock
 
     def _do_shutdown() -> None:
         if tp is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
   "httpx>=0.27,<1",
   "pyyaml>=6,<7",
   "click>=8.1,<9",
+  "opentelemetry-api>=1.24,<2",
+  "opentelemetry-sdk>=1.24,<2",
+  "opentelemetry-exporter-otlp-proto-http>=1.24,<2",
 ]
 
 [project.scripts]

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,0 +1,173 @@
+"""Tests for pulse.otel — OTEL SDK setup, no-op mode, shutdown, etc."""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import pulse.otel as otel_mod
+
+
+def _reset_otel_module() -> None:
+    """Reset module-level state between tests."""
+    otel_mod._tracer_provider = None
+    otel_mod._meter_provider = None
+    otel_mod._shutdown_called = False
+
+
+# ---------------------------------------------------------------------------
+# No-op mode
+# ---------------------------------------------------------------------------
+
+
+def test_noop_mode_no_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """setup() with OTEL_EXPORTER_OTLP_TRACES_ENDPOINT='' completes without error."""
+    _reset_otel_module()
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+
+    otel_mod.setup(service_name="test-noop")  # must not raise
+
+
+def test_noop_mode_tracer_is_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_tracer() returns a usable tracer after no-op setup."""
+    _reset_otel_module()
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+
+    otel_mod.setup(service_name="test-noop")
+    tracer = otel_mod.get_tracer("test")
+    assert tracer is not None
+    # Should be usable (no exporter means spans are just dropped)
+    with tracer.start_as_current_span("test-span"):
+        pass  # must not raise
+
+
+def test_noop_mode_no_exporters_created(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No OTLP exporters are created in no-op mode."""
+    _reset_otel_module()
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+        side_effect=AssertionError("should not be called"),
+    ):
+        try:
+            otel_mod.setup(service_name="test-noop-exporters")
+        except AssertionError:
+            pytest.fail("OTLPSpanExporter was instantiated in no-op mode")
+
+
+# ---------------------------------------------------------------------------
+# Normal mode (fake endpoint)
+# ---------------------------------------------------------------------------
+
+
+def test_normal_mode_setup_completes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """setup() with a fake endpoint completes without raising."""
+    _reset_otel_module()
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+
+    # Patch exporters so we don't need a real collector
+    with (
+        patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter", return_value=MagicMock()),
+        patch("opentelemetry.exporter.otlp.proto.http.metric_exporter.OTLPMetricExporter", return_value=MagicMock()),
+        patch("pulse.otel.PeriodicExportingMetricReader", return_value=MagicMock()),
+        patch("pulse.otel.BatchSpanProcessor", return_value=MagicMock()),
+    ):
+        otel_mod.setup(service_name="test-normal", endpoint="http://fake-host:4318/v1/traces")
+
+
+def test_normal_mode_get_tracer_works(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_tracer() returns a tracer after normal-mode setup."""
+    _reset_otel_module()
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+
+    with (
+        patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter", return_value=MagicMock()),
+        patch("opentelemetry.exporter.otlp.proto.http.metric_exporter.OTLPMetricExporter", return_value=MagicMock()),
+        patch("pulse.otel.PeriodicExportingMetricReader", return_value=MagicMock()),
+        patch("pulse.otel.BatchSpanProcessor", return_value=MagicMock()),
+    ):
+        otel_mod.setup(service_name="test-tracer", endpoint="http://fake-host:4318/v1/traces")
+        tracer = otel_mod.get_tracer("my-component")
+        assert tracer is not None
+
+
+# ---------------------------------------------------------------------------
+# Silent drop — unreachable collector
+# ---------------------------------------------------------------------------
+
+
+def test_silent_drop_one_warning(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Unreachable endpoint → exactly 1 WARNING logged, no exception propagated."""
+    _reset_otel_module()
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", raising=False)
+
+    with (
+        patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter", return_value=MagicMock()),
+        patch("opentelemetry.exporter.otlp.proto.http.metric_exporter.OTLPMetricExporter", return_value=MagicMock()),
+        patch("pulse.otel.PeriodicExportingMetricReader", return_value=MagicMock()),
+        patch("pulse.otel.BatchSpanProcessor", return_value=MagicMock()),
+        caplog.at_level(logging.WARNING, logger="pulse.otel"),
+    ):
+        otel_mod.setup(service_name="test-silent", endpoint="http://unreachable-host:4318/v1/traces")
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "pulse.otel" in r.name]
+    assert len(warnings) == 1, f"Expected 1 warning, got {len(warnings)}: {[r.message for r in warnings]}"
+    assert "unreachable" in warnings[0].message or "silently dropped" in warnings[0].message
+
+
+# ---------------------------------------------------------------------------
+# Shutdown idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """shutdown() called twice raises no exception."""
+    _reset_otel_module()
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+
+    otel_mod.setup(service_name="test-idempotent")
+
+    otel_mod.shutdown(timeout_ms=500)
+    otel_mod.shutdown(timeout_ms=500)  # must not raise
+
+
+def test_shutdown_before_setup_safe() -> None:
+    """shutdown() before setup() is safe (no providers initialised)."""
+    _reset_otel_module()
+    otel_mod.shutdown(timeout_ms=200)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Shutdown timeout enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_shutdown_completes_within_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """shutdown() returns within 2s even if providers hang."""
+    _reset_otel_module()
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+
+    otel_mod.setup(service_name="test-timeout")
+
+    # Make the tracer provider shutdown block for a long time
+    if otel_mod._tracer_provider is not None:
+        original_shutdown = otel_mod._tracer_provider.shutdown
+
+        def slow_shutdown() -> None:
+            time.sleep(10)  # much longer than timeout
+
+        otel_mod._tracer_provider.shutdown = slow_shutdown  # type: ignore[method-assign]
+
+    start = time.monotonic()
+    otel_mod.shutdown(timeout_ms=500)  # 500ms budget
+    elapsed = time.monotonic() - start
+
+    # Should return roughly within timeout + a small margin (e.g. 1s for thread overhead)
+    assert elapsed < 2.0, f"shutdown took {elapsed:.2f}s — exceeded timeout"

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -49,14 +49,13 @@ def test_noop_mode_no_exporters_created(monkeypatch: pytest.MonkeyPatch) -> None
     _reset_otel_module()
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
 
-    with patch(
-        "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
-        side_effect=AssertionError("should not be called"),
-    ):
-        try:
-            otel_mod.setup(service_name="test-noop-exporters")
-        except AssertionError:
-            pytest.fail("OTLPSpanExporter was instantiated in no-op mode")
+    otel_mod.setup(service_name="test-noop-exporters")
+
+    # TracerProvider must be set but have zero active span processors
+    tp = otel_mod._tracer_provider
+    assert tp is not None, "TracerProvider should be set in no-op mode"
+    processors = tp._active_span_processor._span_processors
+    assert len(processors) == 0, f"Expected no span processors in no-op mode, got: {processors}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New `pulse/otel.py`: TracerProvider + MeterProvider setup with BatchSpanProcessor + PeriodicExportingMetricReader
- No-op mode when OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="" (SDK loads, no exporter)
- Graceful unreachable collector: one warning, silent drop after
- Shutdown flush on SIGTERM/SIGINT + atexit, max 2s
- Integrated into __main__.py entry point

## Tests
- No-op mode, normal mode, silent drop, shutdown idempotency, timeout enforcement

Closes #53