### PR TITLE
fix(compact-hook): force IPv4 + tight curl timeouts

### DIFF
--- a/hooks/compact-hook
+++ b/hooks/compact-hook
@@ -17,11 +17,11 @@ CHAT_ID="${TELEGRAM_CHAT_ID:-}"
 
 if [[ "$EVENT" == *"PreCompact"* ]] || [[ "$MATCHER" == *"manual"* && -z "$EVENT" ]]; then
   # Could be PreCompact
-  curl -s -X POST "https://api.telegram.org/bot${BOTTOKEN}/sendMessage" \
+  curl -s -4 --connect-timeout 2 --max-time 4 -X POST "https://api.telegram.org/bot${BOTTOKEN}/sendMessage" \
     -d "chat_id=${CHAT_ID}&text=🗜 Compacting context...&disable_notification=true" \
     > /dev/null 2>&1 || true
 elif [[ "$EVENT" == *"PostCompact"* ]]; then
-  curl -s -X POST "https://api.telegram.org/bot${BOTTOKEN}/sendMessage" \
+  curl -s -4 --connect-timeout 2 --max-time 4 -X POST "https://api.telegram.org/bot${BOTTOKEN}/sendMessage" \
     -d "chat_id=${CHAT_ID}&text=✅ Context compacted.&disable_notification=true" \
     > /dev/null 2>&1 || true
 fi


### PR DESCRIPTION
## Problem

`hooks/compact-hook` is registered as Pre/PostCompact hook with `async: true, timeout: 5`. On this VPS, IPv6 Happy Eyeballs stalls on `api.telegram.org` can exceed 5s — the hook reports "completed successfully" but the curl gets killed mid-send and the Telegram notification never lands. Noticed when a recent `/compact` didn't show the 🗜 banner.

## Fix

Three flags on both curl invocations (PreCompact + PostCompact branches):
- `-4` force IPv4 (skip Happy Eyeballs)
- `--connect-timeout 2`
- `--max-time 4` total call cap well under the 5s hook window

No other changes. Message text, `|| true` swallow, and `-s` silence all preserved.

## Verification

- `bash -n hooks/compact-hook` — exit 0
- Manual PreCompact fire: `real 0m0.550s`, exit 0
- Manual PostCompact fire: `real 0m0.544s`, exit 0

Both well under the 4s `--max-time` cap and the 5s hook window.

## Swarm

Skipped per quota-efficiency policy (3-line additive fix, explicit Liam authorization).