### PR TITLE
fix(collector): stability flag for otelcol.exporter.file

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -30,6 +30,12 @@ bash ~/code/toolbox/collector/install.sh
 The script is idempotent. Re-running it deploys any updated unit file while
 preserving your `~/.config/alloy/config.alloy` if it already exists.
 
+> **Note:** The service unit passes `--stability.level=public-preview` to
+> `alloy run`. This flag is required because `otelcol.exporter.file` is
+> classified as public-preview in Alloy v1.15.1+. Without it, Alloy exits
+> immediately. If you construct the `alloy run` command manually (e.g. for
+> debugging), include this flag or the exporter will not load.
+
 ## Service Management
 
 ```bash

--- a/collector/systemd/user/alloy.service
+++ b/collector/systemd/user/alloy.service
@@ -6,7 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=%h/bin/alloy run %h/.config/alloy/config.alloy
+ExecStart=%h/bin/alloy run --stability.level=public-preview %h/.config/alloy/config.alloy
 Restart=on-failure
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
Closes #91 (follow-up).

Alloy v1.15.1 enforces GA stability by default; `otelcol.exporter.file` is public-preview and requires opt-in flag. Without `--stability.level=public-preview`, Alloy exits immediately on service start.

## Changes
- `collector/systemd/user/alloy.service`: add `--stability.level=public-preview` to `ExecStart`
- `collector/README.md`: document the flag requirement for operators constructing the command manually