### PR TITLE
feat(lib): breadth-first OTEL instrumentation — all CLI tools (#91)

### DIFF
--- a/collector/README.md
+++ b/collector/README.md
@@ -81,25 +81,10 @@ After install (or after restarting dependent services):
 
 4. Verify output file is being written:
    ```bash
-   tail -f ~/.local/share/alloy/traces.jsonl
+   tail -f ~/.local/share/alloy/otlp.jsonl
    ```
 
 5. Restart a connected service (e.g. pulse) and confirm spans appear in the file.
-
-## Logrotate Config
-
-Add to `/etc/logrotate.d/alloy-traces` (or `~/.config/logrotate/alloy-traces`):
-
-```
-/home/<user>/.local/share/alloy/traces.jsonl {
-    weekly
-    rotate 4
-    compress
-    missingok
-    notifempty
-    copytruncate
-}
-```
 
 ## Configuration
 
@@ -112,7 +97,7 @@ enable the Prometheus scraper block.
 Phase 2 will add an end-to-end test that:
 - Starts alloy.service
 - Sends synthetic OTLP spans from each instrumented service
-- Asserts spans appear in `traces.jsonl` within 10 s
+- Asserts spans appear in `otlp.jsonl` within 10 s
 - Reports missing coverage per service
 
 See `tests/test_alloy_config.sh` for the Phase 1 config-parse test.

--- a/collector/config.alloy
+++ b/collector/config.alloy
@@ -25,9 +25,13 @@ otelcol.processor.batch "default" {
 }
 
 // Receives all signals (traces + metrics + logs) and writes to a local file.
+// rotation{} handles file management; append=true is mutually exclusive with rotation.
 otelcol.exporter.file "sink" {
-  path   = env("HOME") + "/.local/share/alloy/traces.jsonl"
-  append = true
+  path = sys.env("HOME") + "/.local/share/alloy/otlp.jsonl"
+  rotation {
+    max_megabytes = 100
+    max_backups   = 4
+  }
 }
 
 // -------------------------------------------------------

--- a/gen-image/gen-image
+++ b/gen-image/gen-image
@@ -23,6 +23,15 @@ import sys
 from pathlib import Path
 from urllib.request import Request, urlopen
 
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'lib'))
+try:
+    import otel_cli
+    otel_cli.setup('gen-image')
+    _tracer = otel_cli.get_tracer(__name__)
+except Exception:
+    otel_cli = None  # type: ignore[assignment]
+    _tracer = None
+
 SECRETS_FILE = Path.home() / ".secrets" / "google-ai.env"
 
 MODELS = {
@@ -84,33 +93,47 @@ def generate_image(prompt: str, model: str, api_key: str, aspect_ratio: str = "1
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate images via Google AI")
-    parser.add_argument("prompt", help="Image description")
-    parser.add_argument("--out", "-o", type=Path, default=None,
-                        help="Output file (default: generated-<timestamp>.png)")
-    parser.add_argument("--model", "-m", default="imagen-4-fast",
-                        choices=list(MODELS.keys()),
-                        help="Model (default: imagen-4-fast)")
-    parser.add_argument("--aspect", "-a", default="1:1",
-                        help="Aspect ratio: 1:1, 16:9, 9:16, 4:3, 3:4 (default: 1:1)")
-    args = parser.parse_args()
+    from opentelemetry import trace as _trace
+    _span_ctx = _tracer.start_as_current_span('gen-image.run') if _tracer else None
+    _span = _span_ctx.__enter__() if _span_ctx else None
+    try:
+        parser = argparse.ArgumentParser(description="Generate images via Google AI")
+        parser.add_argument("prompt", help="Image description")
+        parser.add_argument("--out", "-o", type=Path, default=None,
+                            help="Output file (default: generated-<timestamp>.png)")
+        parser.add_argument("--model", "-m", default="imagen-4-fast",
+                            choices=list(MODELS.keys()),
+                            help="Model (default: imagen-4-fast)")
+        parser.add_argument("--aspect", "-a", default="1:1",
+                            help="Aspect ratio: 1:1, 16:9, 9:16, 4:3, 3:4 (default: 1:1)")
+        args = parser.parse_args()
 
-    api_key = load_api_key()
+        api_key = load_api_key()
 
-    print(f"Generating with {args.model}...", file=sys.stderr)
-    image_data = generate_image(args.prompt, args.model, api_key, args.aspect)
+        print(f"Generating with {args.model}...", file=sys.stderr)
+        image_data = generate_image(args.prompt, args.model, api_key, args.aspect)
 
-    if args.out:
-        output = args.out
-    else:
-        from datetime import datetime
-        ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-        slug = args.prompt[:30].lower().replace(" ", "-").replace("/", "")
-        output = Path(f"/tmp/gen-{ts}-{slug}.png")
+        if args.out:
+            output = args.out
+        else:
+            from datetime import datetime
+            ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+            slug = args.prompt[:30].lower().replace(" ", "-").replace("/", "")
+            output = Path(f"/tmp/gen-{ts}-{slug}.png")
 
-    output.write_bytes(image_data)
-    print(f"{output}", file=sys.stderr)
-    print(str(output))
+        output.write_bytes(image_data)
+        print(f"{output}", file=sys.stderr)
+        print(str(output))
+    except Exception as e:
+        if _span:
+            _span.record_exception(e)
+            _span.set_status(_trace.StatusCode.ERROR, str(e))
+        raise
+    finally:
+        if _span_ctx:
+            _span_ctx.__exit__(None, None, None)
+        if otel_cli:
+            otel_cli.shutdown()
 
 
 if __name__ == "__main__":

--- a/gen-image/gen-image
+++ b/gen-image/gen-image
@@ -127,7 +127,7 @@ def main():
         output.write_bytes(image_data)
         print(f"{output}", file=sys.stderr)
         print(str(output))
-    except Exception as e:
+    except BaseException as e:
         if _span:
             _span.record_exception(e)
             if _trace:

--- a/gen-image/gen-image
+++ b/gen-image/gen-image
@@ -93,7 +93,10 @@ def generate_image(prompt: str, model: str, api_key: str, aspect_ratio: str = "1
 
 
 def main():
-    from opentelemetry import trace as _trace
+    try:
+        from opentelemetry import trace as _trace
+    except ImportError:
+        _trace = None  # type: ignore[assignment]
     _span_ctx = _tracer.start_as_current_span('gen-image.run') if _tracer else None
     _span = _span_ctx.__enter__() if _span_ctx else None
     try:
@@ -127,7 +130,8 @@ def main():
     except Exception as e:
         if _span:
             _span.record_exception(e)
-            _span.set_status(_trace.StatusCode.ERROR, str(e))
+            if _trace:
+                _span.set_status(_trace.StatusCode.ERROR, str(e))
         raise
     finally:
         if _span_ctx:

--- a/hooks/agent-start-hook
+++ b/hooks/agent-start-hook
@@ -2,6 +2,10 @@
 # Hook for SubagentStart: notify Telegram and track agent in JSON file
 set -euo pipefail
 
+# shellcheck source=../lib/otel.sh
+_OTEL_LIB="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)/../lib/otel.sh"
+{ [ -f "$_OTEL_LIB" ] && source "$_OTEL_LIB" && otel_start_span "${0##*/}" && trap 'otel_end_span $?' EXIT; } || true
+
 INPUT=$(cat)
 TRACKER="/tmp/agent-tracker.json"
 

--- a/hooks/agent-stop-hook
+++ b/hooks/agent-stop-hook
@@ -2,6 +2,10 @@
 # Hook for SubagentStop: notify Telegram (threaded) and update tracker
 set -euo pipefail
 
+# shellcheck source=../lib/otel.sh
+_OTEL_LIB="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)/../lib/otel.sh"
+{ [ -f "$_OTEL_LIB" ] && source "$_OTEL_LIB" && otel_start_span "${0##*/}" && trap 'otel_end_span $?' EXIT; } || true
+
 INPUT=$(cat)
 TRACKER="/tmp/agent-tracker.json"
 

--- a/hooks/compact-hook
+++ b/hooks/compact-hook
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# shellcheck source=../lib/otel.sh
+_OTEL_LIB="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)/../lib/otel.sh"
+{ [ -f "$_OTEL_LIB" ] && source "$_OTEL_LIB" && otel_start_span "${0##*/}" && trap 'otel_end_span $?' EXIT; } || true
+
 INPUT=$(cat)
 EVENT=$(echo "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null || true)
 MATCHER=$(echo "$INPUT" | jq -r '.matcher // empty' 2>/dev/null || true)

--- a/hooks/voice-hook
+++ b/hooks/voice-hook
@@ -6,6 +6,10 @@
 
 set -euo pipefail
 
+# shellcheck source=../lib/otel.sh
+_OTEL_LIB="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)/../lib/otel.sh"
+{ [ -f "$_OTEL_LIB" ] && source "$_OTEL_LIB" && otel_start_span "${0##*/}" && trap 'otel_end_span $?' EXIT; } || true
+
 LOG="/tmp/voice-hook.log"
 INPUT=$(cat)
 echo "=== $(date) ===" >> "$LOG"

--- a/lib/otel.sh
+++ b/lib/otel.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# otel.sh — minimal OTEL tracing for bash CLI tools
+# Source this file, then call otel_start_span at the top of your script
+# and set a trap to otel_end_span at the bottom.
+#
+# Usage:
+#   OTEL_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/otel.sh"
+#   [ -f "$OTEL_LIB" ] && source "$OTEL_LIB" && otel_start_span "${0##*/}" || true
+#   trap 'otel_end_span $?' EXIT
+#
+# OTEL instrumentation NEVER breaks the tool — all errors are suppressed with || true.
+# When Alloy/collector is unreachable, the background curl fails silently.
+
+_OTEL_SERVICE_NAME=""
+_OTEL_START_NS=""
+_OTEL_TRACE_ID=""
+_OTEL_SPAN_ID=""
+
+otel_start_span() {
+  local service_name="${1:-${0##*/}}"
+  _OTEL_SERVICE_NAME="$service_name"
+  _OTEL_START_NS=$(date +%s%N)
+  # Generate 16-byte trace ID and 8-byte span ID as hex
+  _OTEL_TRACE_ID=$(cat /proc/sys/kernel/random/uuid 2>/dev/null | tr -d '-' || od -An -tx1 -N16 /dev/urandom | tr -d ' \n')
+  _OTEL_SPAN_ID=$(od -An -tx1 -N8 /dev/urandom | tr -d ' \n')
+}
+
+otel_end_span() {
+  local exit_code="${1:-0}"
+  local end_ns
+  end_ns=$(date +%s%N)
+  local duration_ns=$(( end_ns - _OTEL_START_NS ))
+  local caller_agent="${AGENT_NAME:-cli-direct}"
+  local status_code=0  # OK
+  local status_msg=""
+  if [ "$exit_code" -ne 0 ]; then
+    status_code=2  # ERROR
+    status_msg="exited with code $exit_code"
+  fi
+
+  # Build minimal OTLP JSON and POST to Alloy — fire-and-forget, never blocks the tool
+  local payload
+  payload=$(printf '{
+    "resourceSpans": [{
+      "resource": {
+        "attributes": [
+          {"key": "service.name", "value": {"stringValue": "%s"}},
+          {"key": "caller.agent", "value": {"stringValue": "%s"}}
+        ]
+      },
+      "scopeSpans": [{
+        "scope": {"name": "otel.sh"},
+        "spans": [{
+          "traceId": "%s",
+          "spanId": "%s",
+          "name": "%s",
+          "kind": 1,
+          "startTimeUnixNano": "%s",
+          "endTimeUnixNano": "%s",
+          "attributes": [
+            {"key": "process.exit_code", "value": {"intValue": %d}}
+          ],
+          "status": {"code": %d, "message": "%s"}
+        }]
+      }]
+    }]
+  }' \
+    "$_OTEL_SERVICE_NAME" \
+    "$caller_agent" \
+    "$_OTEL_TRACE_ID" \
+    "$_OTEL_SPAN_ID" \
+    "$_OTEL_SERVICE_NAME" \
+    "$_OTEL_START_NS" \
+    "$end_ns" \
+    "$exit_code" \
+    "$status_code" \
+    "$status_msg")
+
+  # Background curl — || true ensures failure never propagates
+  curl -s --max-time 1 \
+    -H 'Content-Type: application/json' \
+    -d "$payload" \
+    'http://localhost:4318/v1/traces' \
+    >/dev/null 2>&1 &
+  # Don't wait on the background curl — let the tool exit cleanly
+}

--- a/lib/otel.sh
+++ b/lib/otel.sh
@@ -26,11 +26,16 @@ otel_start_span() {
 }
 
 otel_end_span() {
+  [ -z "$_OTEL_START_NS" ] && return 0
   local exit_code="${1:-0}"
   local end_ns
   end_ns=$(date +%s%N)
-  local duration_ns=$(( end_ns - _OTEL_START_NS ))
   local caller_agent="${AGENT_NAME:-cli-direct}"
+  # JSON-escape double-quotes and backslashes in string values
+  local safe_svc="${_OTEL_SERVICE_NAME//\\/\\\\}"
+  safe_svc="${safe_svc//\"/\\\"}"
+  local safe_agent="${caller_agent//\\/\\\\}"
+  safe_agent="${safe_agent//\"/\\\"}"
   local status_code=0  # OK
   local status_msg=""
   if [ "$exit_code" -ne 0 ]; then
@@ -65,11 +70,11 @@ otel_end_span() {
       }]
     }]
   }' \
-    "$_OTEL_SERVICE_NAME" \
-    "$caller_agent" \
+    "$safe_svc" \
+    "$safe_agent" \
     "$_OTEL_TRACE_ID" \
     "$_OTEL_SPAN_ID" \
-    "$_OTEL_SERVICE_NAME" \
+    "$safe_svc" \
     "$_OTEL_START_NS" \
     "$end_ns" \
     "$exit_code" \

--- a/lib/otel_cli.py
+++ b/lib/otel_cli.py
@@ -1,0 +1,104 @@
+"""Minimal OTEL tracing for short-lived CLI tools.
+
+Uses SimpleSpanProcessor for synchronous flush on exit — correct for CLI tools
+that exit fast (unlike long-running services which use BatchSpanProcessor).
+
+Usage:
+    import sys, os
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'lib'))
+    import otel_cli
+
+    otel_cli.setup('tool-name')
+    tracer = otel_cli.get_tracer(__name__)
+
+    with tracer.start_as_current_span('tool-name.run') as span:
+        try:
+            # main logic
+            pass
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(trace.StatusCode.ERROR, str(e))
+            raise
+        finally:
+            otel_cli.shutdown()
+
+No-op mode: set OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="" to load the SDK without
+attaching any exporter — all trace calls become safe no-ops. Useful for tests.
+"""
+from __future__ import annotations
+
+import os
+import signal
+import sys
+from typing import Optional
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource, SERVICE_NAME
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+_provider: Optional[TracerProvider] = None
+
+
+def setup(service_name: str) -> None:
+    """Initialise TracerProvider with SimpleSpanProcessor.
+
+    SimpleSpanProcessor (not Batch) is correct for CLI tools — it flushes
+    synchronously before process exit, ensuring no spans are dropped.
+
+    No-op mode: set OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="" — provider is
+    created with no exporter attached; all span calls are safe no-ops.
+    """
+    global _provider
+    if _provider is not None:
+        return  # already initialized
+
+    resource = Resource.create({
+        SERVICE_NAME: service_name,
+        "caller.agent": os.environ.get("AGENT_NAME", "cli-direct"),
+        "deployment.environment": os.environ.get("NODE_ENV", "production"),
+    })
+    _provider = TracerProvider(resource=resource)
+
+    endpoint = os.environ.get(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "http://localhost:4318/v1/traces",
+    )
+    if endpoint:  # empty string = no-op mode
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+        exporter = OTLPSpanExporter(endpoint=endpoint)
+        _provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    trace.set_tracer_provider(_provider)
+
+
+def get_tracer(name: str) -> trace.Tracer:
+    """Convenience wrapper — returns ``trace.get_tracer(name)``."""
+    return trace.get_tracer(name)
+
+
+def shutdown(timeout_ms: int = 2000) -> None:
+    """Flush and shut down the provider. Idempotent — safe to call multiple times. Never raises."""
+    global _provider
+    if _provider is None:
+        return
+    try:
+        _provider.shutdown()
+    except Exception:
+        pass
+
+
+def _handle_signal(sig, frame) -> None:
+    """SIGTERM/SIGINT handler — flush spans before exit.
+
+    Lesson from Phase 3+4 reviews: without explicit signal handling, a SIGTERM
+    to a CLI tool kills the process before BatchSpanProcessor flushes. With
+    SimpleSpanProcessor this is less critical (sync flush), but explicit handling
+    ensures clean shutdown on Ctrl-C and systemd stop signals.
+    """
+    shutdown()
+    sys.exit(0)
+
+
+signal.signal(signal.SIGTERM, _handle_signal)
+signal.signal(signal.SIGINT, _handle_signal)

--- a/lib/otel_cli.py
+++ b/lib/otel_cli.py
@@ -95,9 +95,12 @@ def _handle_signal(sig, frame) -> None:
     to a CLI tool kills the process before BatchSpanProcessor flushes. With
     SimpleSpanProcessor this is less critical (sync flush), but explicit handling
     ensures clean shutdown on Ctrl-C and systemd stop signals.
+
+    Exit with the conventional signal exit code (128 + signum) so callers and
+    pipelines see the correct status. Using sys.exit(0) would mask interruptions.
     """
     shutdown()
-    sys.exit(0)
+    sys.exit(128 + sig)
 
 
 signal.signal(signal.SIGTERM, _handle_signal)

--- a/lib/otel_cli.py
+++ b/lib/otel_cli.py
@@ -66,10 +66,13 @@ def setup(service_name: str) -> None:
     )
     if endpoint:  # empty string = no-op mode
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-        exporter = OTLPSpanExporter(endpoint=endpoint)
+        exporter = OTLPSpanExporter(endpoint=endpoint, timeout=1)
         _provider.add_span_processor(SimpleSpanProcessor(exporter))
 
     trace.set_tracer_provider(_provider)
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
 
 
 def get_tracer(name: str) -> trace.Tracer:
@@ -86,6 +89,8 @@ def shutdown(timeout_ms: int = 2000) -> None:
         _provider.shutdown()
     except Exception:
         pass
+    finally:
+        _provider = None
 
 
 def _handle_signal(sig, frame) -> None:
@@ -101,7 +106,3 @@ def _handle_signal(sig, frame) -> None:
     """
     shutdown()
     sys.exit(128 + sig)
-
-
-signal.signal(signal.SIGTERM, _handle_signal)
-signal.signal(signal.SIGINT, _handle_signal)

--- a/md-speak/md-speak
+++ b/md-speak/md-speak
@@ -749,7 +749,7 @@ def main():
 
         print(f"{output} ({char_count} chars)", file=sys.stderr)
         print(str(output))
-    except Exception as e:
+    except BaseException as e:
         if _span:
             _span.record_exception(e)
             if _trace:

--- a/md-speak/md-speak
+++ b/md-speak/md-speak
@@ -675,7 +675,10 @@ def stitch_audio(parts: list[str], output_path: str):
 # --- Main ---
 
 def main():
-    from opentelemetry import trace as _trace
+    try:
+        from opentelemetry import trace as _trace
+    except ImportError:
+        _trace = None  # type: ignore[assignment]
     _span_ctx = _tracer.start_as_current_span('md-speak.run') if _tracer else None
     _span = _span_ctx.__enter__() if _span_ctx else None
     try:
@@ -749,7 +752,8 @@ def main():
     except Exception as e:
         if _span:
             _span.record_exception(e)
-            _span.set_status(_trace.StatusCode.ERROR, str(e))
+            if _trace:
+                _span.set_status(_trace.StatusCode.ERROR, str(e))
         raise
     finally:
         if _span_ctx:

--- a/md-speak/md-speak
+++ b/md-speak/md-speak
@@ -31,6 +31,15 @@ from urllib.parse import urlparse
 
 import mistune
 
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'lib'))
+try:
+    import otel_cli
+    otel_cli.setup('md-speak')
+    _tracer = otel_cli.get_tracer(__name__)
+except Exception:
+    otel_cli = None  # type: ignore[assignment]
+    _tracer = None
+
 # --- Voice configuration (env-overridable) ---
 
 VOICES = {
@@ -666,73 +675,87 @@ def stitch_audio(parts: list[str], output_path: str):
 # --- Main ---
 
 def main():
-    parser = argparse.ArgumentParser(description="Read markdown aloud with multiple voices")
-    parser.add_argument("file", help="Markdown file to read")
-    parser.add_argument("--out", "-o", type=Path, default=None, help="Output file (default: <input>.mp3)")
-    parser.add_argument("--no-describe", action="store_true", help="Skip AI descriptions of code/images")
-    args = parser.parse_args()
+    from opentelemetry import trace as _trace
+    _span_ctx = _tracer.start_as_current_span('md-speak.run') if _tracer else None
+    _span = _span_ctx.__enter__() if _span_ctx else None
+    try:
+        parser = argparse.ArgumentParser(description="Read markdown aloud with multiple voices")
+        parser.add_argument("file", help="Markdown file to read")
+        parser.add_argument("--out", "-o", type=Path, default=None, help="Output file (default: <input>.mp3)")
+        parser.add_argument("--no-describe", action="store_true", help="Skip AI descriptions of code/images")
+        args = parser.parse_args()
 
-    md_path = Path(args.file)
-    if not md_path.exists():
-        print(f"error: file not found: {md_path}", file=sys.stderr)
-        sys.exit(1)
+        md_path = Path(args.file)
+        if not md_path.exists():
+            print(f"error: file not found: {md_path}", file=sys.stderr)
+            sys.exit(1)
 
-    output = args.out or md_path.with_suffix(".mp3")
-    md_text = md_path.read_text()
+        output = args.out or md_path.with_suffix(".mp3")
+        md_text = md_path.read_text()
 
-    print(f"Parsing {md_path.name}...", file=sys.stderr)
-    segments = process_markdown(md_text, use_ai=not args.no_describe)
-    print(f"Generated {len(segments)} segments", file=sys.stderr)
+        print(f"Parsing {md_path.name}...", file=sys.stderr)
+        segments = process_markdown(md_text, use_ai=not args.no_describe)
+        print(f"Generated {len(segments)} segments", file=sys.stderr)
 
-    # Batch into SSML by voice
-    batches = segments_to_ssml_batches(segments)
-    chunk_count = len(batches)
-    print(f"Batched into {chunk_count} SSML calls (was {len(segments)} segments)", file=sys.stderr)
-    if chunk_count > 20:
-        print(f"warning: high chunk count ({chunk_count}) — document may be very long or segmentation is fragmented", file=sys.stderr)
+        # Batch into SSML by voice
+        batches = segments_to_ssml_batches(segments)
+        chunk_count = len(batches)
+        print(f"Batched into {chunk_count} SSML calls (was {len(segments)} segments)", file=sys.stderr)
+        if chunk_count > 20:
+            print(f"warning: high chunk count ({chunk_count}) — document may be very long or segmentation is fragmented", file=sys.stderr)
 
-    # Generate audio for each batch
-    tmpdir = tempfile.mkdtemp(prefix="md-speak-")
-    parts: list[str] = []
-    char_count = 0
+        # Generate audio for each batch
+        tmpdir = tempfile.mkdtemp(prefix="md-speak-")
+        parts: list[str] = []
+        char_count = 0
 
-    for i, (ssml, voice) in enumerate(batches):
-        audio_path = f"{tmpdir}/batch-{i}.mp3"
-        # Count chars (rough — includes SSML tags but close enough)
-        text_chars = len(re.sub(r'<[^>]+>', '', ssml))
-        char_count += text_chars
-        preview = re.sub(r'<[^>]+>', '', ssml).strip()[:60]
-        print(f"  [{i+1}/{len(batches)}] {voice}: {preview}{'...' if len(preview) >= 60 else ''}", file=sys.stderr)
-        rate = 1.05 if voice == VOICES["body"] else 0.95
-        generate_ssml_audio(ssml, voice, audio_path, rate=rate)
-        parts.append(audio_path)
+        for i, (ssml, voice) in enumerate(batches):
+            audio_path = f"{tmpdir}/batch-{i}.mp3"
+            # Count chars (rough — includes SSML tags but close enough)
+            text_chars = len(re.sub(r'<[^>]+>', '', ssml))
+            char_count += text_chars
+            preview = re.sub(r'<[^>]+>', '', ssml).strip()[:60]
+            print(f"  [{i+1}/{len(batches)}] {voice}: {preview}{'...' if len(preview) >= 60 else ''}", file=sys.stderr)
+            rate = 1.05 if voice == VOICES["body"] else 0.95
+            generate_ssml_audio(ssml, voice, audio_path, rate=rate)
+            parts.append(audio_path)
 
-    if not parts:
-        print("error: no audio segments generated", file=sys.stderr)
-        sys.exit(1)
+        if not parts:
+            print("error: no audio segments generated", file=sys.stderr)
+            sys.exit(1)
 
-    # Generate "end of document" closing line in the female voice
-    doc_name = md_path.stem.replace("-", " ").replace("_", " ").title()
-    end_ssml = f'<speak><break time="800ms"/><p>{escape_ssml("This is the end of: " + doc_name)}</p></speak>'
-    end_audio_path = f"{tmpdir}/end-segment.mp3"
-    print(f"  [END] {VOICES['special']}: This is the end of: {doc_name}", file=sys.stderr)
-    generate_ssml_audio(end_ssml, VOICES["special"], end_audio_path)
-    parts.append(end_audio_path)
+        # Generate "end of document" closing line in the female voice
+        doc_name = md_path.stem.replace("-", " ").replace("_", " ").title()
+        end_ssml = f'<speak><break time="800ms"/><p>{escape_ssml("This is the end of: " + doc_name)}</p></speak>'
+        end_audio_path = f"{tmpdir}/end-segment.mp3"
+        print(f"  [END] {VOICES['special']}: This is the end of: {doc_name}", file=sys.stderr)
+        generate_ssml_audio(end_ssml, VOICES["special"], end_audio_path)
+        parts.append(end_audio_path)
 
-    print(f"Stitching {len(parts)} audio parts...", file=sys.stderr)
-    stitch_audio(parts, str(output))
+        print(f"Stitching {len(parts)} audio parts...", file=sys.stderr)
+        stitch_audio(parts, str(output))
 
-    # Add metadata (artist, title, album art)
-    doc_title = md_path.stem.replace("-", " ").replace("_", " ").title()
-    add_mp3_metadata(str(output), title=doc_title)
+        # Add metadata (artist, title, album art)
+        doc_title = md_path.stem.replace("-", " ").replace("_", " ").title()
+        add_mp3_metadata(str(output), title=doc_title)
 
-    # Cleanup
-    for p in parts:
-        Path(p).unlink(missing_ok=True)
-    Path(tmpdir).rmdir()
+        # Cleanup
+        for p in parts:
+            Path(p).unlink(missing_ok=True)
+        Path(tmpdir).rmdir()
 
-    print(f"{output} ({char_count} chars)", file=sys.stderr)
-    print(str(output))
+        print(f"{output} ({char_count} chars)", file=sys.stderr)
+        print(str(output))
+    except Exception as e:
+        if _span:
+            _span.record_exception(e)
+            _span.set_status(_trace.StatusCode.ERROR, str(e))
+        raise
+    finally:
+        if _span_ctx:
+            _span_ctx.__exit__(None, None, None)
+        if otel_cli:
+            otel_cli.shutdown()
 
 
 if __name__ == "__main__":

--- a/morning-brief/morning-brief
+++ b/morning-brief/morning-brief
@@ -15,6 +15,10 @@
 
 set -euo pipefail
 
+# shellcheck source=../lib/otel.sh
+_OTEL_LIB="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)/../lib/otel.sh"
+{ [ -f "$_OTEL_LIB" ] && source "$_OTEL_LIB" && otel_start_span "${0##*/}"; } || true
+
 # ── configuration ─────────────────────────────────────────────────────────────
 
 STALE_HOURS="${STALE_HOURS:-48}"
@@ -31,7 +35,7 @@ fi
 # ── temp dir for module outputs ───────────────────────────────────────────────
 
 TMPDIR_BRIEF=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_BRIEF"' EXIT
+trap '_exit_code=$?; rm -rf "$TMPDIR_BRIEF"; { otel_end_span "$_exit_code"; } 2>/dev/null || true' EXIT
 
 # ── module 1: weather ────────────────────────────────────────────────────────
 

--- a/openai-usage/openai-usage
+++ b/openai-usage/openai-usage
@@ -186,7 +186,10 @@ def send_telegram(text: str):
 
 
 def main():
-    from opentelemetry import trace as _trace
+    try:
+        from opentelemetry import trace as _trace
+    except ImportError:
+        _trace = None  # type: ignore[assignment]
     _span_ctx = _tracer.start_as_current_span('openai-usage.run') if _tracer else None
     _span = _span_ctx.__enter__() if _span_ctx else None
     try:
@@ -217,7 +220,8 @@ def main():
     except Exception as e:
         if _span:
             _span.record_exception(e)
-            _span.set_status(_trace.StatusCode.ERROR, str(e))
+            if _trace:
+                _span.set_status(_trace.StatusCode.ERROR, str(e))
         raise
     finally:
         if _span_ctx:

--- a/openai-usage/openai-usage
+++ b/openai-usage/openai-usage
@@ -16,6 +16,15 @@ from pathlib import Path
 from urllib.request import Request, urlopen
 from urllib.parse import quote
 
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'lib'))
+try:
+    import otel_cli
+    otel_cli.setup('openai-usage')
+    _tracer = otel_cli.get_tracer(__name__)
+except Exception:
+    otel_cli = None  # type: ignore[assignment]
+    _tracer = None
+
 SECRETS_FILE = Path.home() / ".secrets" / "openai.env"
 TG_ENV = Path.home() / ".claude" / "channels" / "telegram" / ".env"
 TG_SECRETS = Path.home() / ".secrets" / "telegram.env"
@@ -177,30 +186,44 @@ def send_telegram(text: str):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="OpenAI usage report")
-    parser.add_argument("--days", type=int, default=7, help="Number of days to report (default: 7)")
-    parser.add_argument("--telegram", action="store_true", help="Send report to Telegram")
-    args = parser.parse_args()
+    from opentelemetry import trace as _trace
+    _span_ctx = _tracer.start_as_current_span('openai-usage.run') if _tracer else None
+    _span = _span_ctx.__enter__() if _span_ctx else None
+    try:
+        parser = argparse.ArgumentParser(description="OpenAI usage report")
+        parser.add_argument("--days", type=int, default=7, help="Number of days to report (default: 7)")
+        parser.add_argument("--telegram", action="store_true", help="Send report to Telegram")
+        args = parser.parse_args()
 
-    admin_key = load_key("OPENAI_ADMIN_KEY", SECRETS_FILE)
+        admin_key = load_key("OPENAI_ADMIN_KEY", SECRETS_FILE)
 
-    now = datetime.now(timezone.utc)
-    end_ts = int(now.timestamp())
-    start_ts = int((now - timedelta(days=args.days)).timestamp())
+        now = datetime.now(timezone.utc)
+        end_ts = int(now.timestamp())
+        start_ts = int((now - timedelta(days=args.days)).timestamp())
 
-    print(f"Fetching costs and usage for last {args.days} days...", file=sys.stderr)
+        print(f"Fetching costs and usage for last {args.days} days...", file=sys.stderr)
 
-    costs = get_costs(admin_key, start_ts, end_ts)
-    completions = get_usage(admin_key, start_ts, end_ts, "completions")
-    audio = get_usage(admin_key, start_ts, end_ts, "audio_transcriptions")
+        costs = get_costs(admin_key, start_ts, end_ts)
+        completions = get_usage(admin_key, start_ts, end_ts, "completions")
+        audio = get_usage(admin_key, start_ts, end_ts, "audio_transcriptions")
 
-    report = format_report(args.days, costs, completions, audio)
+        report = format_report(args.days, costs, completions, audio)
 
-    if args.telegram:
-        send_telegram(report)
-        print("Sent to Telegram", file=sys.stderr)
-    else:
-        print(report)
+        if args.telegram:
+            send_telegram(report)
+            print("Sent to Telegram", file=sys.stderr)
+        else:
+            print(report)
+    except Exception as e:
+        if _span:
+            _span.record_exception(e)
+            _span.set_status(_trace.StatusCode.ERROR, str(e))
+        raise
+    finally:
+        if _span_ctx:
+            _span_ctx.__exit__(None, None, None)
+        if otel_cli:
+            otel_cli.shutdown()
 
 
 if __name__ == "__main__":

--- a/openai-usage/openai-usage
+++ b/openai-usage/openai-usage
@@ -217,7 +217,7 @@ def main():
             print("Sent to Telegram", file=sys.stderr)
         else:
             print(report)
-    except Exception as e:
+    except BaseException as e:
         if _span:
             _span.record_exception(e)
             if _trace:

--- a/speak/speak
+++ b/speak/speak
@@ -201,7 +201,10 @@ ALL_VOICES = sorted(OPENAI_VOICES | set(ELEVENLABS_VOICES.keys()))
 
 
 def main():
-    from opentelemetry import trace as _trace
+    try:
+        from opentelemetry import trace as _trace
+    except ImportError:
+        _trace = None  # type: ignore[assignment]
     _span_ctx = _tracer.start_as_current_span('speak.run') if _tracer else None
     _span = _span_ctx.__enter__() if _span_ctx else None
     try:
@@ -252,7 +255,8 @@ def main():
     except Exception as e:
         if _span:
             _span.record_exception(e)
-            _span.set_status(_trace.StatusCode.ERROR, str(e))
+            if _trace:
+                _span.set_status(_trace.StatusCode.ERROR, str(e))
         raise
     finally:
         if _span_ctx:

--- a/speak/speak
+++ b/speak/speak
@@ -252,7 +252,7 @@ def main():
             print(f"{args.out}", file=sys.stderr)
         else:
             sys.stdout.buffer.write(audio_data)
-    except Exception as e:
+    except BaseException as e:
         if _span:
             _span.record_exception(e)
             if _trace:

--- a/speak/speak
+++ b/speak/speak
@@ -30,6 +30,15 @@ import sys
 import tempfile
 from pathlib import Path
 
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'lib'))
+try:
+    import otel_cli
+    otel_cli.setup('speak')
+    _tracer = otel_cli.get_tracer(__name__)
+except Exception:
+    otel_cli = None  # type: ignore[assignment]
+    _tracer = None
+
 # --- Provider: OpenAI ---
 
 OPENAI_VOICES = {"alloy", "ash", "ballad", "coral", "echo", "fable", "nova", "onyx", "sage", "shimmer"}
@@ -192,50 +201,64 @@ ALL_VOICES = sorted(OPENAI_VOICES | set(ELEVENLABS_VOICES.keys()))
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Text-to-speech with multiple providers")
-    parser.add_argument("text", nargs="?", default=None, help="Text to speak (or pipe via stdin)")
-    parser.add_argument("--provider", "-p", default="openai", choices=["openai", "google", "elevenlabs"],
-                        help="TTS provider (default: openai)")
-    parser.add_argument("--voice", "-v", default=None,
-                        help=f"Voice name (default: {OPENAI_DEFAULT_VOICE} for openai, {GOOGLE_DEFAULT_VOICE} for google, {ELEVENLABS_DEFAULT_VOICE} for elevenlabs)")
-    parser.add_argument("--model", default="flash", choices=ELEVENLABS_MODELS.keys(),
-                        help="ElevenLabs model (default: flash, ignored for openai)")
-    parser.add_argument("--out", type=Path, default=None, help="Output file path (default: stdout)")
-    parser.add_argument("--mp3", action="store_true", help="Output mp3 instead of ogg opus")
-    args = parser.parse_args()
+    from opentelemetry import trace as _trace
+    _span_ctx = _tracer.start_as_current_span('speak.run') if _tracer else None
+    _span = _span_ctx.__enter__() if _span_ctx else None
+    try:
+        parser = argparse.ArgumentParser(description="Text-to-speech with multiple providers")
+        parser.add_argument("text", nargs="?", default=None, help="Text to speak (or pipe via stdin)")
+        parser.add_argument("--provider", "-p", default="openai", choices=["openai", "google", "elevenlabs"],
+                            help="TTS provider (default: openai)")
+        parser.add_argument("--voice", "-v", default=None,
+                            help=f"Voice name (default: {OPENAI_DEFAULT_VOICE} for openai, {GOOGLE_DEFAULT_VOICE} for google, {ELEVENLABS_DEFAULT_VOICE} for elevenlabs)")
+        parser.add_argument("--model", default="flash", choices=ELEVENLABS_MODELS.keys(),
+                            help="ElevenLabs model (default: flash, ignored for openai)")
+        parser.add_argument("--out", type=Path, default=None, help="Output file path (default: stdout)")
+        parser.add_argument("--mp3", action="store_true", help="Output mp3 instead of ogg opus")
+        args = parser.parse_args()
 
-    if args.text:
-        text = args.text
-    elif not sys.stdin.isatty():
-        text = sys.stdin.read().strip()
-    else:
-        print("error: provide text as an argument or pipe via stdin", file=sys.stderr)
-        sys.exit(1)
-
-    if not text:
-        print("error: empty text", file=sys.stderr)
-        sys.exit(1)
-
-    ogg = not args.mp3
-
-    if args.provider == "openai":
-        voice = args.voice or OPENAI_DEFAULT_VOICE
-        if voice not in OPENAI_VOICES:
-            print(f"error: unknown openai voice '{voice}'. Available: {', '.join(sorted(OPENAI_VOICES))}", file=sys.stderr)
+        if args.text:
+            text = args.text
+        elif not sys.stdin.isatty():
+            text = sys.stdin.read().strip()
+        else:
+            print("error: provide text as an argument or pipe via stdin", file=sys.stderr)
             sys.exit(1)
-        audio_data, ext = speak_openai(text, voice, ogg)
-    elif args.provider == "google":
-        voice = args.voice or GOOGLE_DEFAULT_VOICE
-        audio_data, ext = speak_google(text, voice, ogg)
-    else:
-        voice = args.voice or ELEVENLABS_DEFAULT_VOICE
-        audio_data, ext = speak_elevenlabs(text, voice, args.model, ogg)
 
-    if args.out:
-        args.out.write_bytes(audio_data)
-        print(f"{args.out}", file=sys.stderr)
-    else:
-        sys.stdout.buffer.write(audio_data)
+        if not text:
+            print("error: empty text", file=sys.stderr)
+            sys.exit(1)
+
+        ogg = not args.mp3
+
+        if args.provider == "openai":
+            voice = args.voice or OPENAI_DEFAULT_VOICE
+            if voice not in OPENAI_VOICES:
+                print(f"error: unknown openai voice '{voice}'. Available: {', '.join(sorted(OPENAI_VOICES))}", file=sys.stderr)
+                sys.exit(1)
+            audio_data, ext = speak_openai(text, voice, ogg)
+        elif args.provider == "google":
+            voice = args.voice or GOOGLE_DEFAULT_VOICE
+            audio_data, ext = speak_google(text, voice, ogg)
+        else:
+            voice = args.voice or ELEVENLABS_DEFAULT_VOICE
+            audio_data, ext = speak_elevenlabs(text, voice, args.model, ogg)
+
+        if args.out:
+            args.out.write_bytes(audio_data)
+            print(f"{args.out}", file=sys.stderr)
+        else:
+            sys.stdout.buffer.write(audio_data)
+    except Exception as e:
+        if _span:
+            _span.record_exception(e)
+            _span.set_status(_trace.StatusCode.ERROR, str(e))
+        raise
+    finally:
+        if _span_ctx:
+            _span_ctx.__exit__(None, None, None)
+        if otel_cli:
+            otel_cli.shutdown()
 
 
 if __name__ == "__main__":

--- a/tests/test_alloy_config.sh
+++ b/tests/test_alloy_config.sh
@@ -6,11 +6,14 @@ CONFIG="$SCRIPT_DIR/../collector/config.alloy"
 
 ALLOY_BIN="$HOME/bin/alloy"
 if [ ! -x "$ALLOY_BIN" ]; then
+  if [ -n "${CI:-}" ]; then
+    echo "ERROR: $ALLOY_BIN not found — cannot skip in CI"
+    exit 1
+  fi
   echo "SKIP: $ALLOY_BIN not found or not executable — install Alloy first"
-  exit 0
+  exit 77
 fi
 
-echo "==> Checking Alloy config: $CONFIG"
-# Validates config syntax via alloy fmt (alloy validate does not exist in 1.x)
-"$ALLOY_BIN" fmt --write=false "$CONFIG" > /dev/null
-echo "PASS: config.alloy is valid"
+echo "==> Validating Alloy config: $CONFIG"
+"$ALLOY_BIN" validate --stability.level=public-preview "$CONFIG"
+echo "PASS: config.alloy is valid (component graph + syntax)"

--- a/tests/test_otel_bash.sh
+++ b/tests/test_otel_bash.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Smoke test: otel.sh sourcing + otel_start_span/otel_end_span don't crash
+# even when Alloy is unreachable (OTLP blocked by firewall or collector down)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/otel.sh"
+otel_start_span "test-tool"
+trap 'otel_end_span $?' EXIT
+echo "PASS: otel.sh sourced and span started"
+exit 0

--- a/tests/test_otel_python.sh
+++ b/tests/test_otel_python.sh
@@ -2,7 +2,12 @@
 # Smoke test: otel_cli.py imports + setup + shutdown with no-op (empty endpoint)
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="" /home/claude/venvs/transcribe/bin/python3 -c "
+PYTHON="${HOME}/venvs/transcribe/bin/python3"
+if [ ! -x "$PYTHON" ]; then
+    echo "SKIP: venv not found at $PYTHON — install opentelemetry deps first"
+    exit 77
+fi
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="" "$PYTHON" -c "
 import sys; sys.path.insert(0, '$SCRIPT_DIR/../lib')
 import otel_cli
 otel_cli.setup('test-tool')

--- a/tests/test_otel_python.sh
+++ b/tests/test_otel_python.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Smoke test: otel_cli.py imports + setup + shutdown with no-op (empty endpoint)
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="" /home/claude/venvs/transcribe/bin/python3 -c "
+import sys; sys.path.insert(0, '$SCRIPT_DIR/../lib')
+import otel_cli
+otel_cli.setup('test-tool')
+tracer = otel_cli.get_tracer('test')
+with tracer.start_as_current_span('test.run'):
+    pass
+otel_cli.shutdown()
+print('PASS: otel_cli setup + shutdown OK')
+"

--- a/transcribe/transcribe
+++ b/transcribe/transcribe
@@ -111,7 +111,7 @@ def main():
         finally:
             if converted:
                 converted.unlink(missing_ok=True)
-    except Exception as e:
+    except BaseException as e:
         if _span:
             _span.record_exception(e)
             if _trace:

--- a/transcribe/transcribe
+++ b/transcribe/transcribe
@@ -16,12 +16,22 @@ Requires OPENAI_API_KEY in the environment.
 """
 
 import argparse
+import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
 from openai import OpenAI
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'lib'))
+try:
+    import otel_cli
+    otel_cli.setup('transcribe')
+    _tracer = otel_cli.get_tracer(__name__)
+except Exception:
+    otel_cli = None  # type: ignore[assignment]
+    _tracer = None
 
 DEFAULT_GLOSSARY = Path(__file__).resolve().parent / "glossary.txt"
 MINI_MODEL = "gpt-4o-mini-transcribe"
@@ -63,37 +73,51 @@ def transcribe(audio_path: str, model: str, prompt: str | None) -> str:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Transcribe audio via OpenAI API")
-    parser.add_argument("audio_file", help="Path to the audio file")
-    parser.add_argument("--full", action="store_true", help=f"Use {FULL_MODEL} (default: {MINI_MODEL})")
-    parser.add_argument("--no-glossary", action="store_true", help="Skip glossary prompt")
-    parser.add_argument("--glossary", type=Path, default=None, help="Custom glossary file path")
-    args = parser.parse_args()
-
-    audio = Path(args.audio_file)
-    if not audio.exists():
-        print(f"error: file not found: {audio}", file=sys.stderr)
-        sys.exit(1)
-
-    converted = None
-    if audio.suffix.lower() not in SUPPORTED_FORMATS:
-        print(f"converting {audio.suffix} to mp3...", file=sys.stderr)
-        audio = converted = convert_to_mp3(audio)
-
-    model = FULL_MODEL if args.full else MINI_MODEL
-
-    if args.no_glossary:
-        prompt = None
-    else:
-        glossary_path = args.glossary if args.glossary else DEFAULT_GLOSSARY
-        prompt = load_glossary(glossary_path)
-
+    from opentelemetry import trace as _trace
+    _span_ctx = _tracer.start_as_current_span('transcribe.run') if _tracer else None
+    _span = _span_ctx.__enter__() if _span_ctx else None
     try:
-        text = transcribe(str(audio), model, prompt)
-        print(text)
+        parser = argparse.ArgumentParser(description="Transcribe audio via OpenAI API")
+        parser.add_argument("audio_file", help="Path to the audio file")
+        parser.add_argument("--full", action="store_true", help=f"Use {FULL_MODEL} (default: {MINI_MODEL})")
+        parser.add_argument("--no-glossary", action="store_true", help="Skip glossary prompt")
+        parser.add_argument("--glossary", type=Path, default=None, help="Custom glossary file path")
+        args = parser.parse_args()
+
+        audio = Path(args.audio_file)
+        if not audio.exists():
+            print(f"error: file not found: {audio}", file=sys.stderr)
+            sys.exit(1)
+
+        converted = None
+        if audio.suffix.lower() not in SUPPORTED_FORMATS:
+            print(f"converting {audio.suffix} to mp3...", file=sys.stderr)
+            audio = converted = convert_to_mp3(audio)
+
+        model = FULL_MODEL if args.full else MINI_MODEL
+
+        if args.no_glossary:
+            prompt = None
+        else:
+            glossary_path = args.glossary if args.glossary else DEFAULT_GLOSSARY
+            prompt = load_glossary(glossary_path)
+
+        try:
+            text = transcribe(str(audio), model, prompt)
+            print(text)
+        finally:
+            if converted:
+                converted.unlink(missing_ok=True)
+    except Exception as e:
+        if _span:
+            _span.record_exception(e)
+            _span.set_status(_trace.StatusCode.ERROR, str(e))
+        raise
     finally:
-        if converted:
-            converted.unlink(missing_ok=True)
+        if _span_ctx:
+            _span_ctx.__exit__(None, None, None)
+        if otel_cli:
+            otel_cli.shutdown()
 
 
 if __name__ == "__main__":

--- a/transcribe/transcribe
+++ b/transcribe/transcribe
@@ -73,7 +73,10 @@ def transcribe(audio_path: str, model: str, prompt: str | None) -> str:
 
 
 def main():
-    from opentelemetry import trace as _trace
+    try:
+        from opentelemetry import trace as _trace
+    except ImportError:
+        _trace = None  # type: ignore[assignment]
     _span_ctx = _tracer.start_as_current_span('transcribe.run') if _tracer else None
     _span = _span_ctx.__enter__() if _span_ctx else None
     try:
@@ -111,7 +114,8 @@ def main():
     except Exception as e:
         if _span:
             _span.record_exception(e)
-            _span.set_status(_trace.StatusCode.ERROR, str(e))
+            if _trace:
+                _span.set_status(_trace.StatusCode.ERROR, str(e))
         raise
     finally:
         if _span_ctx:


### PR DESCRIPTION
## Summary

- Adds `lib/otel.sh`: source-able bash OTEL library (`otel_start_span` / `otel_end_span`). Fire-and-forget curl to Alloy at `localhost:4318`. All errors suppressed — never breaks the wrapped tool.
- Adds `lib/otel_cli.py`: Python OTEL library using `SimpleSpanProcessor` (correct for CLI tools that exit fast). SIGTERM/SIGINT handlers flush before exit with proper `128+sig` exit codes.
- Instruments **4 hook scripts** in `hooks/`: `agent-start-hook`, `agent-stop-hook`, `compact-hook`, `voice-hook`
- Instruments **5 Python tools**: `md-speak`, `transcribe`, `speak`, `gen-image`, `openai-usage`
- Instruments **morning-brief** bash tool with composite EXIT trap (preserves existing `rm -rf $TMPDIR_BRIEF` cleanup)
- Instruments **20 additional bash tools** in `~/bin/` (not tracked in toolbox repo — standalone files): `backup-shared-r2`, `check-shared-backup-freshness`, `claude-code-ntfy-notify`, `codex-exec-ntfy`, `codex-ntfy-notify`, `compact-snapshot-read`, `compact-snapshot-write`, `create-companion-candidate`, `deploy-companion-prod`, `deploy-t3code-prod`, `devils-advocate`, `gh`, `gh-pr-cycle`, `gh-pr-rebase-lockfile`, `pr-review`, `publish-shared`, `run-companion-dev`, `system-watchdog`, `update-t3code`, `upgrade-companion-safe`
- Adds smoke tests: `tests/test_otel_bash.sh` and `tests/test_otel_python.sh` — both verified passing

## Key design decisions

- Caller attribution via `$AGENT_NAME` env var, falls back to `cli-direct` when unset
- All bash instrumentation wrapped in `{ ... } || true` — OTEL missing or erroring never breaks the tool
- `SimpleSpanProcessor` not `BatchSpanProcessor` — CLI tools exit fast; sync flush ensures spans aren't dropped
- Python tools share `~/venvs/transcribe/` venv (additive deps only, no conflicts): `opentelemetry-api==1.41.0`, `opentelemetry-sdk==1.41.0`, `opentelemetry-exporter-otlp-proto-http==1.41.0`

## Notes

- `port-for` and `skill-metrics` use system Python — `opentelemetry` not installed system-wide. Skipped for now.
- **Future venv audit follow-up:** per SOP, each tool should eventually have its own `~/venvs/<tool>/` venv. The 5 Python tools currently sharing `~/venvs/transcribe/` is a known debt item. Opening a follow-up GH issue is recommended.
- `update-t3code` uses `exec` to replace the process — EXIT trap fires before exec (bash behavior), but this is best-effort.

## Test results

```
PASS: otel.sh sourced and span started
PASS: otel_cli setup + shutdown OK
```

## Swarm review

- Tier 1 (Claude): CLEAN after fix
- Tier 2 (Codex): no actionable findings surfaced
- Tier 3 (Gemini): flagged `sys.exit(0)` in signal handler — fixed to `sys.exit(128+sig)` before push

Closes #91