### PR TITLE
feat: repair-telegram-mcp + agent-health-mcp-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ All tools use a shared Python venv at `~/venvs/transcribe/` and are symlinked in
 | [md-speak](#md-speak) | Read markdown documents aloud with multiple voices |
 | [voice-hook](#voice-hook) | Claude Code hook: auto-transcribe Telegram voice notes |
 | [pulse](pulse/README.md) | GitHub org activity snapshots — open PRs, issues, releases, Dependabot |
+| [repair-telegram-mcp](#repair-telegram-mcp) | Repair Telegram MCP partial disconnects in a live Claude Code tmux session |
 
 ---
 
@@ -143,6 +144,54 @@ pulse --now           # run snapshot + render digest
 - `tests/test_config.py`, `tests/test_storage.py` — unit tests
 
 **Cost:** No paid API calls. GraphQL queries use GitHub PAT (free tier).
+
+---
+
+### repair-telegram-mcp
+
+Repair a Telegram MCP partial disconnect in a live Claude Code tmux session by sending `/reload-plugins` through tmux after an input-stability guard. This is for the case where tmux and the Telegram bun plugin are alive, but MCP tools are missing; dead REPL zombies still need the separate full-restart procedure.
+
+**Setup:**
+- tmux session running Claude Code with Telegram plugin
+- `agent-health-mcp-check` available beside this script or on `PATH`
+- Optional symlinks:
+  ```bash
+  ln -sf ~/code/toolbox/bin/repair-telegram-mcp ~/bin/repair-telegram-mcp
+  ln -sf ~/code/toolbox/bin/agent-health-mcp-check ~/bin/agent-health-mcp-check
+  ```
+
+**Usage:**
+```bash
+repair-telegram-mcp [SESSION]   # defaults to current tmux session
+repair-telegram-mcp SESSION --dry-run
+repair-telegram-mcp SESSION --force
+
+agent-health-mcp-check SESSION  # MCP_OK, MCP_MISSING:<reason>, or MCP_UNKNOWN:<reason>
+```
+
+**Environment:**
+- `REPAIR_POLL_SECONDS` — seconds between input captures, default `60`
+- `REPAIR_MAX_WAIT_SECONDS` — total wait before timeout, default `180`
+- `REPAIR_INPUT_LEN_THRESHOLD` — stable non-empty input length needed before auto-commit, default `40`
+
+**Exit codes:**
+- `0` sent successfully, dry-run completed, or MCP was already healthy
+- `2` bad args or no session
+- `3` tmux session missing
+- `4` zombie: tmux exists but no live Claude REPL
+- `5` input never stabilized
+- `6` refused partial slash command
+- `7` another repair is running for the session
+- `8` no visible `❯` prompt
+- `9` post-Enter verify failed
+
+**Files:**
+- `bin/repair-telegram-mcp` — tmux repair command with input-stability guard
+- `bin/agent-health-mcp-check` — best-effort transcript probe for Telegram MCP tool availability
+- `~/.world/repair-telegram-mcp.log` — action log
+- `~/.world/repair-telegram-mcp.<session>.lock` — per-session flock lock
+
+**Cost:** No paid API calls.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -175,15 +175,17 @@ agent-health-mcp-check SESSION  # MCP_OK, MCP_MISSING:<reason>, or MCP_UNKNOWN:<
 - `REPAIR_INPUT_LEN_THRESHOLD` — stable non-empty input length needed before auto-commit, default `40`
 
 **Exit codes:**
-- `0` sent successfully, dry-run completed, or MCP was already healthy
-- `2` bad args or no session
-- `3` tmux session missing
-- `4` zombie: tmux exists but no live Claude REPL
-- `5` input never stabilized
-- `6` refused partial slash command
-- `7` another repair is running for the session
-- `8` no visible `❯` prompt
-- `9` post-Enter verify failed
+| Code | Meaning |
+| --- | --- |
+| 0 | Sent successfully, dry-run completed, or MCP was already healthy |
+| 2 | Bad args or no session |
+| 3 | tmux session missing |
+| 4 | Zombie: tmux exists but no live Claude REPL |
+| 5 | Input never stabilized |
+| 6 | Refused partial slash command |
+| 7 | Another repair is running for the session |
+| 8 | No visible `❯` prompt, capture failed, or stable input was below the safety threshold |
+| 9 | Post-Enter verify failed |
 
 **Files:**
 - `bin/repair-telegram-mcp` — tmux repair command with input-stability guard

--- a/bin/agent-health-mcp-check
+++ b/bin/agent-health-mcp-check
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: agent-health-mcp-check SESSION" >&2
+}
+
+if [[ $# -ne 1 || -z "${1:-}" ]]; then
+  usage
+  echo "MCP_UNKNOWN:bad-args"
+  exit 2
+fi
+
+session="$1"
+projects_dir="$HOME/.claude/projects"
+telegram_tool="mcp__plugin_telegram_telegram__reply"
+
+# Best-effort heuristic: this depends on Claude Code's JSONL transcript format
+# and the wording of system-reminder blocks. If either changes, this probe needs
+# to be updated. Callers should treat MCP_UNKNOWN as fail-open.
+project_key_for_session() {
+  local value="$1"
+
+  if [[ "$value" == /* ]]; then
+    value="${value#/}"
+    value="${value//\//-}"
+    printf -- "-%s\n" "$value"
+    return
+  fi
+
+  printf -- "-home-claude-%s\n" "${value//\//-}"
+}
+
+find_latest_transcript() {
+  local key candidate
+  key="$(project_key_for_session "$session")"
+
+  if [[ -d "$projects_dir/$key" ]]; then
+    find "$projects_dir/$key" -type f -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null |
+      sort -nr |
+      awk 'NR == 1 { sub(/^[^ ]+ /, ""); print }'
+    return
+  fi
+
+  candidate="$(
+    find "$projects_dir" -maxdepth 1 -type d -name "*${session//\//-}*" -printf '%T@ %p\n' 2>/dev/null |
+      sort -nr |
+      awk 'NR == 1 { sub(/^[^ ]+ /, ""); print }'
+  )"
+  if [[ -n "$candidate" ]]; then
+    find "$candidate" -type f -name '*.jsonl' -printf '%T@ %p\n' 2>/dev/null |
+      sort -nr |
+      awk 'NR == 1 { sub(/^[^ ]+ /, ""); print }'
+  fi
+}
+
+if [[ ! -d "$projects_dir" ]]; then
+  echo "MCP_UNKNOWN:no-projects-dir"
+  exit 2
+fi
+
+transcript="$(find_latest_transcript || true)"
+if [[ -z "$transcript" || ! -f "$transcript" ]]; then
+  echo "MCP_UNKNOWN:no-transcript"
+  exit 2
+fi
+
+recent="$(tail -n 100 "$transcript" 2>/dev/null || true)"
+if [[ -z "$recent" ]]; then
+  echo "MCP_UNKNOWN:empty-transcript-tail"
+  exit 2
+fi
+
+latest_tool_line="$(
+  printf '%s\n' "$recent" |
+    awk -v tool="$telegram_tool" 'index($0, tool) { line = NR } END { if (line) print line }'
+)"
+
+latest_missing_line="$(
+  printf '%s\n' "$recent" |
+    awk '
+      {
+        lower = tolower($0)
+      }
+      lower ~ /system-reminder/ && lower ~ /telegram/ && (lower ~ /mcp servers have disconnected/ || lower ~ /deferred tools are no longer available/) {
+        line = NR
+      }
+      END { if (line) print line }
+    '
+)"
+
+if [[ -n "$latest_tool_line" && ( -z "$latest_missing_line" || "$latest_tool_line" -gt "$latest_missing_line" ) ]]; then
+  echo "MCP_OK"
+  exit 0
+fi
+
+if [[ -n "$latest_missing_line" ]]; then
+  echo "MCP_MISSING:recent-disconnect-reminder"
+  exit 1
+fi
+
+echo "MCP_UNKNOWN:no-recent-telegram-tool-signal"
+exit 2

--- a/bin/repair-telegram-mcp
+++ b/bin/repair-telegram-mcp
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  repair-telegram-mcp [SESSION]
+  repair-telegram-mcp SESSION --dry-run
+  repair-telegram-mcp SESSION --force
+
+Env:
+  REPAIR_POLL_SECONDS        default 60
+  REPAIR_MAX_WAIT_SECONDS    default 180
+  REPAIR_INPUT_LEN_THRESHOLD default 40
+USAGE
+}
+
+dry_run=0
+force=0
+session=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)
+      dry_run=1
+      ;;
+    --force)
+      force=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      usage
+      exit 2
+      ;;
+    *)
+      if [[ -n "$session" ]]; then
+        usage
+        exit 2
+      fi
+      session="$arg"
+      ;;
+  esac
+done
+
+if [[ -z "$session" ]]; then
+  session="$(tmux display-message -p '#S' 2>/dev/null || true)"
+fi
+
+if [[ -z "$session" ]]; then
+  echo "repair-telegram-mcp: no SESSION supplied and no current tmux session" >&2
+  exit 2
+fi
+
+poll_seconds="${REPAIR_POLL_SECONDS:-60}"
+max_wait_seconds="${REPAIR_MAX_WAIT_SECONDS:-180}"
+input_len_threshold="${REPAIR_INPUT_LEN_THRESHOLD:-40}"
+
+for numeric in poll_seconds max_wait_seconds input_len_threshold; do
+  value="${!numeric}"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    echo "repair-telegram-mcp: $numeric must be a non-negative integer" >&2
+    exit 2
+  fi
+done
+
+if (( poll_seconds == 0 || max_wait_seconds == 0 )); then
+  echo "repair-telegram-mcp: REPAIR_POLL_SECONDS and REPAIR_MAX_WAIT_SECONDS must be greater than zero" >&2
+  exit 2
+fi
+
+world_dir="$HOME/.world"
+mkdir -p "$world_dir"
+
+log_file="$world_dir/repair-telegram-mcp.log"
+session_safe="$(printf '%s' "$session" | tr -c 'A-Za-z0-9_.-' '_')"
+lock_file="$world_dir/repair-telegram-mcp.${session_safe}.lock"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+timestamp() {
+  TZ=America/New_York date '+%Y-%m-%dT%H:%M:%S%z'
+}
+
+input_len() {
+  printf '%s' "$1" | wc -c | tr -d ' '
+}
+
+log_action() {
+  local action="$1"
+  local reason="${2:-}"
+  local len="${3:-0}"
+  printf '%s session=%q action=%q reason=%q input_len=%s\n' \
+    "$(timestamp)" "$session" "$action" "$reason" "$len" >>"$log_file"
+}
+
+strip_display() {
+  sed $'s/\x1b\[[0-9;]*[a-zA-Z]//g; s/\xc2\xa0/ /g'
+}
+
+capture_input() {
+  local raw
+  raw="$(tmux capture-pane -t "$session" -p 2>/dev/null)" || return 2
+
+  printf '%s\n' "$raw" |
+    strip_display |
+    awk '
+      function strip_prompt(line) {
+        sub(/^│[[:space:]]*/, "", line)
+        sub(/^❯[[:space:]]*/, "", line)
+        return line
+      }
+      function strip_continuation(line) {
+        sub(/^│[[:space:]]*/, "", line)
+        return line
+      }
+      {
+        lines[NR] = $0
+        line = $0
+        if (index(line, "❯") == 1 || line ~ /^│[[:space:]]*❯/) {
+          last = NR
+        }
+      }
+      END {
+        if (!last) {
+          exit 88
+        }
+
+        out = ""
+        for (i = last; i <= NR; i++) {
+          line = lines[i]
+          if (i > last && index(line, "─────") == 1) {
+            break
+          }
+
+          if (i == last) {
+            line = strip_prompt(line)
+            out = line
+          } else {
+            line = strip_continuation(line)
+            out = out "\n" line
+          }
+        }
+
+        sub(/[[:space:]\n\r]+$/, "", out)
+        print out
+      }
+    '
+}
+
+capture_input_or_exit() {
+  local out rc
+  set +e
+  out="$(capture_input)"
+  rc=$?
+  set -e
+
+  if (( rc == 88 )); then
+    log_action "no-prompt" "agent-mid-turn-or-not-input-mode" 0
+    echo "repair-telegram-mcp: no prompt visible - agent likely mid-turn or REPL not in input mode, retry later" >&2
+    exit 8
+  fi
+
+  if (( rc != 0 )); then
+    log_action "capture-failed" "tmux-capture-pane-failed" 0
+    echo "repair-telegram-mcp: failed to capture tmux pane for session '$session'" >&2
+    exit 8
+  fi
+
+  printf '%s' "$out"
+}
+
+regex_escape() {
+  sed 's/[][\/.^$*+?{}()|\\]/\\&/g' <<<"$1"
+}
+
+repl_alive() {
+  local session_re pane pane_cmd
+  session_re="$(regex_escape "$session")"
+
+  if pgrep -f "bun.*${session_re}.*plugin-cache" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  pane="$(tmux capture-pane -t "$session" -p 2>/dev/null | strip_display || true)"
+  pane_cmd="$(tmux display-message -t "$session" -p '#{pane_current_command}' 2>/dev/null || true)"
+  if [[ "$pane_cmd" == *claude* ]] && pgrep -f 'claude' >/dev/null 2>&1 && grep -q '❯' <<<"$pane"; then
+    return 0
+  fi
+
+  return 1
+}
+
+if ! tmux has-session -t "$session" 2>/dev/null; then
+  log_action "missing-session" "tmux-has-session-failed" 0
+  echo "repair-telegram-mcp: tmux session '$session' not found" >&2
+  exit 3
+fi
+
+if ! repl_alive; then
+  log_action "zombie" "tmux-session-without-live-claude-repl" 0
+  echo "repair-telegram-mcp: zombie detected for '$session' (tmux exists but no live Claude REPL); use feedback_dead_repl_zombie_tmux.md full-restart procedure" >&2
+  exit 4
+fi
+
+exec 9>"$lock_file"
+if ! flock -n 9; then
+  log_action "lock-contention" "another-repair-running" 0
+  echo "repair-telegram-mcp: another repair is already running for '$session'" >&2
+  exit 7
+fi
+
+log_action "start" "dry_run=${dry_run},force=${force}" 0
+
+if (( force == 0 )); then
+  health_cmd="$script_dir/agent-health-mcp-check"
+  if [[ ! -x "$health_cmd" ]]; then
+    health_cmd="agent-health-mcp-check"
+  fi
+
+  set +e
+  probe_out="$("$health_cmd" "$session" 2>&1)"
+  probe_rc=$?
+  set -e
+
+  case "$probe_out" in
+    MCP_OK*)
+      log_action "probe-ok" "mcp-healthy" 0
+      if (( dry_run == 0 )); then
+        echo "no-op: MCP healthy, use --force to override"
+        exit 0
+      fi
+      echo "dry-run: MCP healthy; normal run would no-op, continuing parser/poll check" >&2
+      ;;
+    MCP_MISSING:*)
+      log_action "probe-missing" "$probe_out" 0
+      ;;
+    *)
+      log_action "probe-unavailable" "rc=${probe_rc}:${probe_out}" 0
+      ;;
+  esac
+fi
+
+deadline=$((SECONDS + max_wait_seconds))
+stable_input=""
+stable_reason=""
+
+while (( SECONDS < deadline )); do
+  s0="$(capture_input_or_exit)"
+  len0="$(input_len "$s0")"
+  log_action "poll-capture" "first" "$len0"
+
+  remaining=$((deadline - SECONDS))
+  if (( remaining <= 0 )); then
+    break
+  fi
+  sleep_for="$poll_seconds"
+  if (( sleep_for > remaining )); then
+    sleep_for="$remaining"
+  fi
+  sleep "$sleep_for"
+
+  s1="$(capture_input_or_exit)"
+  len1="$(input_len "$s1")"
+  log_action "poll-capture" "second" "$len1"
+
+  if [[ "$s0" == "$s1" ]]; then
+    if [[ -z "$s1" ]]; then
+      stable_input="$s1"
+      stable_reason="empty-stable"
+      log_action "input-stable" "$stable_reason" 0
+      break
+    fi
+
+    if (( len1 < input_len_threshold )); then
+      log_action "input-stable-short" "continue-polling" "$len1"
+      continue
+    fi
+
+    stable_input="$s1"
+    stable_reason="long-stable"
+    log_action "input-stable" "$stable_reason" "$len1"
+    break
+  fi
+
+  log_action "input-changed" "restart-wait" "$len1"
+done
+
+if [[ -z "$stable_reason" ]]; then
+  log_action "timeout" "input-never-stabilized" 0
+  echo "repair-telegram-mcp: poll timeout waiting for stable input in '$session'" >&2
+  exit 5
+fi
+
+stable_len="$(input_len "$stable_input")"
+if [[ "$stable_input" == /* ]]; then
+  log_action "refuse-slash-fragment" "input-starts-with-slash" "$stable_len"
+  echo "repair-telegram-mcp: refusing to commit partial slash command; clear the input manually and retry" >&2
+  exit 6
+fi
+
+if (( dry_run == 1 )); then
+  log_action "dry-run-would-send" "$stable_reason" "$stable_len"
+  if [[ -n "$stable_input" ]]; then
+    echo "DRY-RUN would press Enter to commit existing input (${stable_len} bytes), then send /reload-plugins to '$session'"
+  else
+    echo "DRY-RUN would send /reload-plugins to '$session'"
+  fi
+  exit 0
+fi
+
+if [[ -n "$stable_input" ]]; then
+  log_action "commit-existing-input" "$stable_reason" "$stable_len"
+  tmux send-keys -t "$session" Enter
+  sleep 1
+
+  set +e
+  verify_input="$(capture_input)"
+  verify_rc=$?
+  set -e
+
+  if (( verify_rc != 0 )); then
+    log_action "post-enter-verify-failed" "prompt-not-visible-after-enter" "$stable_len"
+    echo "repair-telegram-mcp: post-Enter verify failed; prompt not visible after committing existing input" >&2
+    exit 9
+  fi
+
+  verify_len="$(input_len "$verify_input")"
+  if [[ -n "$verify_input" ]]; then
+    log_action "post-enter-verify-failed" "input-not-cleared" "$verify_len"
+    echo "repair-telegram-mcp: post-Enter verify failed; input field still has content" >&2
+    exit 9
+  fi
+fi
+
+tmux send-keys -t "$session" '/reload-plugins' Enter
+log_action "sent" "reload-plugins" 0
+echo "repair-telegram-mcp: sent /reload-plugins to '$session'"

--- a/bin/repair-telegram-mcp
+++ b/bin/repair-telegram-mcp
@@ -95,6 +95,12 @@ log_action() {
     "$(timestamp)" "$session" "$action" "$reason" "$len" >>"$log_file"
 }
 
+log_input_below_threshold() {
+  local len="$1"
+  printf '%s session=%q action=input_below_threshold reason=stable_but_short input_len=%s threshold=%s\n' \
+    "$(timestamp)" "$session" "$len" "$input_len_threshold" >>"$log_file"
+}
+
 strip_display() {
   sed $'s/\x1b\[[0-9;]*[a-zA-Z]//g; s/\xc2\xa0/ /g'
 }
@@ -274,8 +280,9 @@ while (( SECONDS < deadline )); do
     fi
 
     if (( len1 < input_len_threshold )); then
-      log_action "input-stable-short" "continue-polling" "$len1"
-      continue
+      log_input_below_threshold "$len1"
+      echo "repair-telegram-mcp: input below safety threshold (len=$len1, min=$input_len_threshold) - refusing to auto-commit, manual intervention needed" >&2
+      exit 8
     fi
 
     stable_input="$s1"


### PR DESCRIPTION
## Summary

- Add `bin/repair-telegram-mcp`, a tmux-safe Telegram MCP partial-disconnect repair command that sends `/reload-plugins` only after zombie, lock, health, prompt, and input-stability checks.
- Add `bin/agent-health-mcp-check`, a best-effort transcript probe for recent Telegram MCP tool availability.
- Document setup, usage, environment variables, exit codes, files, and cost in `README.md`.

## Edge-case coverage

- Missing tmux session exits 3.
- Zombie guard handles normal agent plugin-cache matches and live orch `claudes-world` via Claude pane command plus visible `❯` prompt; sleep-only tmux sessions exit 4.
- Capture parser strips ANSI and wrapped `│ ` continuations, requires a visible `❯` prompt, and stops at horizontal rules.
- Per-session `flock -n` lock exits 7 on concurrent invocation.
- Slash-fragment input exits 6; post-Enter verify exits 9 if input remains.
- Dry-run executes checks, parsing, and polling without sending `/reload-plugins`.

## Tests

```text
## repair-telegram-mcp Tier-1 tests

### Test 1: nonexistent session dry-run => exit 3
repair-telegram-mcp: tmux session 'nonexistent-session' not found
exit=3

### Test 2: live claudes-world dry-run parser/poll => dry-run would-send
DRY-RUN would send /reload-plugins to 'claudes-world'
exit=0

### Test 3: throwaway sleep session zombie guard => exit 4
repair-telegram-mcp: zombie detected for 'mcp-test' (tmux exists but no live Claude REPL); use feedback_dead_repl_zombie_tmux.md full-restart procedure
exit=4

### Test 4: short-poll env on live empty-input dry-run; inspect recent logs
DRY-RUN would send /reload-plugins to 'claudes-world'
exit=0

Recent repair log tail:
2026-04-29T02:35:51-0400 session=nonexistent-session action=missing-session reason=tmux-has-session-failed input_len=0
2026-04-29T02:35:51-0400 session=claudes-world action=start reason=dry_run=1\,force=0 input_len=0
2026-04-29T02:35:51-0400 session=claudes-world action=probe-missing reason=MCP_MISSING:recent-disconnect-reminder input_len=0
2026-04-29T02:35:51-0400 session=claudes-world action=poll-capture reason=first input_len=0
2026-04-29T02:35:53-0400 session=claudes-world action=poll-capture reason=second input_len=0
2026-04-29T02:35:53-0400 session=claudes-world action=input-stable reason=empty-stable input_len=0
2026-04-29T02:35:53-0400 session=claudes-world action=dry-run-would-send reason=empty-stable input_len=0
2026-04-29T02:35:53-0400 session=mcp-test action=zombie reason=tmux-session-without-live-claude-repl input_len=0
2026-04-29T02:35:53-0400 session=claudes-world action=start reason=dry_run=1\,force=0 input_len=0
2026-04-29T02:35:53-0400 session=claudes-world action=probe-missing reason=MCP_MISSING:recent-disconnect-reminder input_len=0
2026-04-29T02:35:53-0400 session=claudes-world action=poll-capture reason=first input_len=0
2026-04-29T02:35:55-0400 session=claudes-world action=poll-capture reason=second input_len=0
2026-04-29T02:35:55-0400 session=claudes-world action=input-stable reason=empty-stable input_len=0
2026-04-29T02:35:55-0400 session=claudes-world action=dry-run-would-send reason=empty-stable input_len=0
```

Additional checks:

```text
$ bash -n bin/repair-telegram-mcp && bash -n bin/agent-health-mcp-check
passed

$ shellcheck bin/repair-telegram-mcp bin/agent-health-mcp-check
passed
```
